### PR TITLE
added messages container

### DIFF
--- a/src/components/organisms/MessagesContainer.vue
+++ b/src/components/organisms/MessagesContainer.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="flex">
+    <div class="w-full md:w-1/4 md:border md:border-r-0 md:border-gray">Inbox</div>
+    <div class="flex-auto hidden md:block md:border md:border-gray">Conversational Area</div>
+  </div>
+</template>
+
+<script lang="ts">
+export default ({
+
+  setup() {
+    return {
+    };
+  },
+
+});
+</script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -21,16 +21,19 @@
         Notice
     </router-link>
     </p>
-
+    
+    <messages-container />
   </div>
 </template>
 
 <script>
+import MessagesContainer from '../components/organisms/MessagesContainer.vue';
 // @ is an alias to /src
 
 export default {
   name: 'Home',
   components: {
+    MessagesContainer
   },
 };
 </script>


### PR DESCRIPTION
Description

Currently built out the messages container with conversational area hidden for medium screens. The #DEDEDE border colour, handling small screen conversational area and height will need to be accounted for in future PR's

![image](https://user-images.githubusercontent.com/69208837/121235549-ffddac80-c862-11eb-89f1-e63e61943e6c.png)
![image](https://user-images.githubusercontent.com/69208837/121235641-108e2280-c863-11eb-8a4c-95cfefb8f1df.png)
