### PR TITLE
added custom height of 50% viewport

### DIFF
--- a/src/components/organisms/MessagesContainer.vue
+++ b/src/components/organisms/MessagesContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex md:h-96">
+  <div class="flex md:h-vh-1/2">
     <div class="w-full md:w-1/3 md:border md:border-r-0 md:border-gray flex flex-col">
       <inbox />
     </div>

--- a/src/components/organisms/MessagesContainer.vue
+++ b/src/components/organisms/MessagesContainer.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="flex md:h-vh-1/2">
-    <div class="w-full md:w-1/3 md:border md:border-r-0 md:border-gray flex flex-col">
+    <div
+      class="
+        w-full
+        md:w-1/3 md:border md:border-r-0 md:border-gray
+        flex flex-col
+      "
+    >
       <inbox />
     </div>
     <div

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,6 +45,9 @@ module.exports = {
           light: "#FFC7BD",
         },
       },
+      height:{
+        "vh-1/2": "50vh"
+      }
     },
   },
   variants: {},


### PR DESCRIPTION
Description

Can now set custom heights in tailwind.
Messages container is leveraging the 1/2 viewport height