### PR TITLE
Moved SkipNav into header + added label to SkipNav

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,8 @@
 <template>
   <div id="app">
+    <!-- skip nav component -->
+    <the-skip-nav />
+
     <!-- The header component -->
     <the-header />
 
@@ -22,6 +25,7 @@
 <script lang="ts">
 import TheHeader from "./components/molecules/TheHeader.vue";
 import TheFooter from "./components/molecules/TheFooter.vue";
+import TheSkipNav from "./components/molecules/TheSkipNav.vue";
 import FeedbackButton from "./components/atoms/FeedbackButton.vue";
 
 export default {
@@ -30,6 +34,7 @@ export default {
     TheHeader,
     TheFooter,
     FeedbackButton,
+    TheSkipNav,
   },
 };
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,6 @@
 <template>
   <div id="app">
     <!-- The header component -->
-    <the-skip-nav />
-
-    <!-- The header component -->
     <the-header />
 
     <!-- Page content -->
@@ -23,7 +20,6 @@
 </template>
 
 <script lang="ts">
-import TheSkipNav from "./components/molecules/TheSkipNav.vue";
 import TheHeader from "./components/molecules/TheHeader.vue";
 import TheFooter from "./components/molecules/TheFooter.vue";
 import FeedbackButton from "./components/atoms/FeedbackButton.vue";
@@ -31,7 +27,6 @@ import FeedbackButton from "./components/atoms/FeedbackButton.vue";
 export default {
   name: "App",
   components: {
-    TheSkipNav,
     TheHeader,
     TheFooter,
     FeedbackButton,

--- a/src/components/molecules/TheHeader.vue
+++ b/src/components/molecules/TheHeader.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <header>
+      <the-skip-nav />
+
       <div class="pb-2 sm:pb-4 sm:border-b sm:border-gray-infomd">
         <!-- Hidden heading -->
         <h2 class="sr-only">Site Header Information</h2>
@@ -130,11 +132,14 @@
 <script lang="ts">
 import Menu from "../atoms/Menu.vue";
 import Banner from "../atoms/Banner.vue";
+import TheSkipNav from "./TheSkipNav.vue";
+
 export default {
   name: "TheHeader",
   components: {
     Menu,
     Banner,
+    TheSkipNav,
   },
   setup() {
     return {};

--- a/src/components/molecules/TheHeader.vue
+++ b/src/components/molecules/TheHeader.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
     <header>
-      <the-skip-nav />
-
       <div class="pb-2 sm:pb-4 sm:border-b sm:border-gray-infomd">
         <!-- Hidden heading -->
         <h2 class="sr-only">Site Header Information</h2>
@@ -132,14 +130,12 @@
 <script lang="ts">
 import Menu from "../atoms/Menu.vue";
 import Banner from "../atoms/Banner.vue";
-import TheSkipNav from "./TheSkipNav.vue";
 
 export default {
   name: "TheHeader",
   components: {
     Menu,
     Banner,
-    TheSkipNav,
   },
   setup() {
     return {};

--- a/src/components/molecules/TheSkipNav.vue
+++ b/src/components/molecules/TheSkipNav.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- Site Accessibility Navigation -->
-    <ul class="sr-only">
+    <ul class="sr-only" aria-label="Skip Navigation Link">
       <li>
         <a href="#maincontent">Skip to main content</a>
       </li>

--- a/src/components/molecules/TheSkipNav.vue
+++ b/src/components/molecules/TheSkipNav.vue
@@ -1,12 +1,12 @@
 <template>
-  <div>
+  <nav>
     <!-- Site Accessibility Navigation -->
     <ul class="sr-only" aria-label="Skip Navigation Link">
       <li>
         <a href="#maincontent">Skip to main content</a>
       </li>
     </ul>
-  </div>
+  </nav>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
### [VCON-114 Page content contained by landmarks](https://decdvirtualconcierge.atlassian.net/browse/VCON-114?atlOrigin=eyJpIjoiYmE5NTA4ZmE0ZTJjNDUzY2EyM2QyYTU0ZjBjNmE5NzMiLCJwIjoiaiJ9)

## Description
This moved the SkipNav, which was outside all [page landmarks](https://dequeuniversity.com/rules/axe/4.2/region?application=AxeChrome) (headers, footers, and other sections), into the very top of the header so that it complied with accessibility guidelines/regulations. 

I also added a aria-label for the skip nav, I'm not 100% sure if that's appropriate/necessary for the component though.