### PR TITLE
Vcon 135 rectangular messages

### DIFF
--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -3,7 +3,7 @@
     <p
       :class="[
         !isUser ? 'bg-gray-infolt' : 'bg-blue-primary text-white float-right',
-        ' p-3 rounded-3xl max-w-xs md:max-w-xl min-w-msg text-center',
+        ' p-3 rounded-3xl max-w-xs md:max-w-xl min-w-7/2r text-center',
       ]"
     >
       {{ text }}

--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -3,7 +3,7 @@
     <p
       :class="[
         !isUser ? 'bg-gray-infolt' : 'bg-blue-primary text-white float-right',
-        ' p-3 rounded-3xl max-w-xs md:max-w-xl',
+        ' p-3 rounded-3xl max-w-xs md:max-w-xl min-w-msg text-center',
       ]"
     >
       {{ text }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,6 +57,9 @@ module.exports = {
         "vh-1/3": "calc(100vh / 3)",
         "vh-1/4": "calc(100vh / 4)",
         "vh-1/5": "calc(100vh / 5)",
+      },
+      minWidth: {
+        "msg": "3.5rem"
       }
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -59,7 +59,7 @@ module.exports = {
         "vh-1/5": "calc(100vh / 5)",
       },
       minWidth: {
-        "msg": "3.5rem"
+        "7/2r": "3.5rem"
       }
     },
   },


### PR DESCRIPTION
### [VCON 135 Chat bubbles - turn circles into rectangles w rounded corners ](https://decdvirtualconcierge.atlassian.net/browse/VCON-135?atlOrigin=eyJpIjoiOGI4NjZhMjNjNTNiNDg2ZWI1M2QyYzYzZDdlOTM5NDYiLCJwIjoiaiJ9)

## Description
Just added a minimum width in tailwind and applied it the chat messages + centered the text so it didn't look weird. The rem value looks a little strange, but as far as I can tell, the standard minimum size is equivalent to a 3-letter message or so on most chat applications (tested on Instagram and on iMessages) which I implemented here as well.

## Note 
Tailwind doesn't have any default minimum sizes aside from 0, full, and content-based min/max, so I added a custom minimum size for the messages. This could be easily added for other parts of the application.