### PR TITLE
added margins to conversation messages

### DIFF
--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -2,7 +2,9 @@
   <div :class="[!isUser ? 'flex' : '', 'my-3']">
     <p
       :class="[
-        !isUser ? 'bg-gray-infolt' : 'bg-blue-primary text-white float-right',
+        !isUser
+          ? 'bg-gray-infolt mr-10'
+          : 'ml-10 bg-blue-primary text-white float-right',
         ' p-3 rounded-3xl max-w-xs md:max-w-xl',
       ]"
     >


### PR DESCRIPTION
### [VCON 153 Chat Bubble Overlap](https://decdvirtualconcierge.atlassian.net/browse/VCON-153?atlOrigin=eyJpIjoiZGE5OTQ3ZGY1OGMwNDBmOTg5MjRkMjczYTY1YWZmNzMiLCJwIjoiaiJ9)

## Description 
Fixes the issue of there being too much overlap between messages on small screen sizes. Image below shows the amount of margin that the messages will have on each side (40px).

![image](https://user-images.githubusercontent.com/45071113/123149401-39034880-d42f-11eb-9797-48c1959121d5.png)
