### PR TITLE
made header+input box sticky

### DIFF
--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="w-full h-full flex flex-col p-4 sm:p-0 text-gray-dark">
-    <message-header
-      backIcon="Back"
-      :imageName="chatMessage.senderIcon"
-      :altText="chatMessage.senderIconAltText"
-      :headerText="chatMessage.senderName"
-    />
+    <div class="sticky top-0 opacity-95 bg-white md:opacity-100">
+      <message-header
+        backIcon="Back"
+        :imageName="chatMessage.senderIcon"
+        :altText="chatMessage.senderIconAltText"
+        :headerText="chatMessage.senderName"
+      />
+    </div>
     <div class="flex h-full overflow-auto">
       <img
         :src="icons[chatMessage.senderIcon]"
@@ -32,9 +34,11 @@
         <p class="text-center font-light text-gray-dark">WEDS 10:04 AM</p>
       </div>
     </div>
-    <!-- The logic on how the buttonOptions are passed as props will 
+    <div class="sticky bottom-0">
+      <!-- The logic on how the buttonOptions are passed as props will 
                  depend on how we get the possible answers from VC. -->
-    <TextInput :buttonOptions="['Yes', 'No']" @add-message="sendMessage" />
+      <TextInput :buttonOptions="['Yes', 'No']" @add-message="sendMessage" />
+    </div>
   </div>
 </template>
 <script>


### PR DESCRIPTION
## [VCON-173](https://decdvirtualconcierge.atlassian.net/browse/VCON-173?atlOrigin=eyJpIjoiM2RkZDZkOWU5ZjFkNDYyZDg5MDU5MWNiNGJjOGI3YzgiLCJwIjoiaiJ9) [VCON-185](https://decdvirtualconcierge.atlassian.net/browse/VCON-185?atlOrigin=eyJpIjoiNjk4YTM3MjFjNmMzNGVlNDhkN2I0MjdmNGJjZjJlYTYiLCJwIjoiaiJ9) Make mobile header/input box sticky

### Description
The header and input box are now sticky on the mobile view. 
Also added a bit of transparency (95%) to the header. 

### Additional Notes
Note that this did _not_ make the header on the email view sticky nor transparent/make that specific header component sticky everywhere else. Will change if that is preferred.
~~Also, the components are still sticky on desktop, but since that the screen can't be moved that far, I don't think it can be seen on desktop views. Will change if it's an issue.~~
It is an issue on landscape mode for certain mobile devices, however simply adding a breakpoint class `md:relative` to override the sticky class doesn't seem to work. 
