### PR TITLE
fixed the vh for xl

### DIFF
--- a/src/components/organisms/MessagesContainer.vue
+++ b/src/components/organisms/MessagesContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex md:h-vh-3/5 text-gray-dark">
+  <div class="flex md:h-vh-3/5 xl:h-vh-2/3 text-gray-dark">
     <div
       class="
         w-full


### PR DESCRIPTION
## [VCON-151](https://decdvirtualconcierge.atlassian.net/browse/VCON-151)

### Description
I forgot to make the change for the xl height to 2/3 for the message container and it caused the feedback button to overlap the inbox. 

### Additional Notes
check xl screen size and make sure the feedback button is not overlapping the inbox section. 
