### PR TITLE
adjusted margins and paddings in conversation window

### DIFF
--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -20,6 +20,7 @@
           flex flex-col-reverse
           font-body
           text-gray-dark
+          pr-6
           pb-4
           pt-2
         "

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -20,8 +20,8 @@
           flex flex-col-reverse
           font-body
           text-gray-dark
-          py-px
-          px-2
+          pb-4
+          pt-2
         "
         tabindex="0"
       >


### PR DESCRIPTION
## [VCON-183](https://decdvirtualconcierge.atlassian.net/browse/VCON-183?atlOrigin=eyJpIjoiODMwNTA5MzBkN2UwNGVmNjg1YzUwNmQxOWNiNWY5OTgiLCJwIjoiaiJ9)

### Description
Modified the margins such that the VC icon would have an equal amount of space on either side of it.

### Additional Notes
Also added some vertical padding as I had noticed that there was some in the figma but not on the site.
