### PR TITLE
VCON 148 Send icon states

### DIFF
--- a/src/assets/icons.js
+++ b/src/assets/icons.js
@@ -1,11 +1,22 @@
+//Message header icons
 import Mail from "./UserAccount/Mail.svg";
 import VC from "./UserAccount/VirtualConcierge.svg";
+
+//"go back" icon variants (for mobile)
 import Back from "./Back/default.svg";
 import BackFocused from "./Back/focused.svg";
+
+//send message icon variants
+import SendActive from "./Send/Active/Default.svg";
+import SendActiveFocused from "./Send/Active/focused.svg";
+import SendInactive from "./Send/Inactive/Default.svg";
 
 export default {
   Mail,
   VC,
   Back,
   BackFocused,
+  SendActive,
+  SendActiveFocused,
+  SendInactive,
 };

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -6,7 +6,7 @@
     v-model="text"
     aria-label="Send message"
     @keyup.enter="sendText"
-    @change="checkSendBtnActive"
+    @input="checkSendBtnActive"
   />
   <div class="w-auto bg-gray-infolt text-gray-dark">
     <chat-option-button

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -6,6 +6,7 @@
     v-model="text"
     aria-label="Send message"
     @keyup.enter="sendText"
+    @onchange="checkSendBtnActive"
   />
   <div class="w-auto bg-gray-infolt text-gray-dark">
     <chat-option-button
@@ -18,9 +19,12 @@
       class="float-right cursor-pointer"
       aria-label="Send message"
       @click="sendText"
+      @focus="onSendBtnFocus"
+      @blur="checkSendBtnActive"
     >
       <img
-        src="../../assets/Send/Active/Default.svg"
+        class="focus:border-none"
+        :src="icons[iconState]"
         alt="Send Image."
         aria-hidden="true"
       />
@@ -28,8 +32,13 @@
   </div>
 </template>
 <script>
+import icons from "../../assets/icons.js";
+
 import ChatOptionButton from "./ChatOptionButton.vue";
 import { ref } from "vue";
+
+//let iconState = "SendInactive"
+
 export default {
   name: "TextInput",
   props: {
@@ -41,6 +50,8 @@ export default {
   emits: ["add-message"],
   setup(_, context) {
     const text = ref("");
+    const iconState = ref("SendInactive");
+
     function sendText() {
       if (this.text.length > 0) {
         context.emit("add-message", this.text);
@@ -52,10 +63,21 @@ export default {
         context.emit("add-message", btnText);
       }
     }
+    function onSendBtnFocus() {
+      iconState.value =
+        text.value === "" ? "SendInactive" : "SendActiveFocused";
+    }
+    function checkSendBtnActive() {
+      iconState.value = text.value === "" ? "SendInactive" : "SendActive";
+    }
     return {
       text,
+      icons,
+      iconState,
       sendText,
       sendBtnText,
+      onSendBtnFocus,
+      checkSendBtnActive,
     };
   },
 };

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -17,10 +17,9 @@
       @send-button="sendBtnText"
     />
     <button
-      ref="sendMsgBtn"
       class="float-right cursor-pointer"
       aria-label="Send message"
-      tabindex="0"
+      :tabindex="sendMsgBtnTabIndex"
       @click="sendText"
       @focus="onSendBtnFocus"
       @mouseover="onSendBtnFocus"
@@ -42,8 +41,6 @@ import icons from "../../assets/icons.js";
 import ChatOptionButton from "./ChatOptionButton.vue";
 import { ref } from "vue";
 
-//let iconState = "SendInactive"
-
 export default {
   name: "TextInput",
   props: {
@@ -55,12 +52,12 @@ export default {
   emits: ["add-message"],
   setup(_, context) {
     const text = ref("");
+    const sendMsgBtnTabIndex = ref(-1); //should be inactive as there's no input text at the start
     const iconState = ref("SendInactive");
 
-    //these refs are reassigned to their respective components on mounting
-    //as with other refs, the actual elements are accessed with .value (input.value, for example)
+    //this ref are reassigned to their respective components on mounting
+    //the actual component is accessed by using input.value
     const input = ref(null);
-    const sendMsgBtn = ref(null);
 
     function sendText() {
       if (this.text.length > 0) {
@@ -81,11 +78,11 @@ export default {
     }
     function checkSendBtnActive() {
       let textEmpty = text.value === "";
-      sendMsgBtn.value.tabIndex = textEmpty ? -1 : 0; //the send button will be untabbable if there's no text
+      sendMsgBtnTabIndex.value = textEmpty ? -1 : 0; //the send button will be untabbable if there's no text
       iconState.value = textEmpty ? "SendInactive" : "SendActive";
     }
     return {
-      sendMsgBtn,
+      sendMsgBtnTabIndex,
       input,
       text,
       icons,

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -1,5 +1,6 @@
 <template>
   <input
+    ref="input"
     type="text"
     placeholder="Write something..."
     class="w-full border-t border-b border-gray-200 p-3 bg-clip-padding"
@@ -16,10 +17,14 @@
       @send-button="sendBtnText"
     />
     <button
+      ref="sendMsgBtn"
       class="float-right cursor-pointer"
       aria-label="Send message"
+      tabindex="0"
       @click="sendText"
       @focus="onSendBtnFocus"
+      @mouseover="onSendBtnFocus"
+      @mouseleave="checkSendBtnActive"
       @blur="checkSendBtnActive"
     >
       <img
@@ -52,11 +57,17 @@ export default {
     const text = ref("");
     const iconState = ref("SendInactive");
 
+    //these refs are reassigned to their respective components on mounting
+    //as with other refs, the actual elements are accessed with .value (input.value, for example)
+    const input = ref(null);
+    const sendMsgBtn = ref(null);
+
     function sendText() {
       if (this.text.length > 0) {
         context.emit("add-message", this.text);
         text.value = "";
         checkSendBtnActive();
+        input.value.focus();
       }
     }
     function sendBtnText(btnText) {
@@ -69,9 +80,13 @@ export default {
         text.value === "" ? "SendInactive" : "SendActiveFocused";
     }
     function checkSendBtnActive() {
-      iconState.value = text.value === "" ? "SendInactive" : "SendActive";
+      let textEmpty = text.value === "";
+      sendMsgBtn.value.tabIndex = textEmpty ? -1 : 0; //the send button will be untabbable if there's no text
+      iconState.value = textEmpty ? "SendInactive" : "SendActive";
     }
     return {
+      sendMsgBtn,
+      input,
       text,
       icons,
       iconState,

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -6,7 +6,7 @@
     v-model="text"
     aria-label="Send message"
     @keyup.enter="sendText"
-    @onchange="checkSendBtnActive"
+    @change="checkSendBtnActive"
   />
   <div class="w-auto bg-gray-infolt text-gray-dark">
     <chat-option-button
@@ -56,6 +56,7 @@ export default {
       if (this.text.length > 0) {
         context.emit("add-message", this.text);
         text.value = "";
+        checkSendBtnActive();
       }
     }
     function sendBtnText(btnText) {


### PR DESCRIPTION
## [VCON-148](https://decdvirtualconcierge.atlassian.net/browse/VCON-148?atlOrigin=eyJpIjoiYTU3ZTVjYzQzY2MwNDRiY2ExNGNlYjA5NGM1NmYzOGQiLCJwIjoiaiJ9) 

### Description
Added states to the send icon:
- when there's any text inputted, the icon will update to be active
- if there is no text (text deleted/sent) the icon will be in its inactive state. ~~it can still be focused upon, but not used~~ can no longer be tabbed to if there is no text
- upon tabbing to/hovering over the button, if there's text in the input, the send icon will transition to the focused state
- tabbing away/hovering out will return the button to the active state
- hitting enter while focused/clicking the button will immediately send the message and set the icon to the inactive state

### Additional Notes
~~Focus state is not activated on click as of yet. Not sure if that's actually needed, will talk to Thomas about it.~~
Focus state activates on hover/tab.
~~Also the outline is still there, dunno how to fix that. Will probably ask Sheila or someone else about that.~~
Sheila has said that it is a non-issue as the focus border always appears on tabbing.