### PR TITLE
Reversed structural order of chat window content so that it is in order without css

### DIFF
--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -22,6 +22,7 @@
           space-y-2 space-y-reverse
           overflow-auto
           flex flex-col
+          justify-end
           font-body
           text-gray-dark
           py-2

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -21,7 +21,7 @@
           w-full
           space-y-2 space-y-reverse
           overflow-auto
-          flex flex-col-reverse
+          flex flex-col
           font-body
           text-gray-dark
           py-2
@@ -29,15 +29,15 @@
         "
         tabindex="0"
       >
+        <p class="text-center font-heading text-sm font-light text-gray-dark">
+          WEDS 10:04 AM
+        </p>
         <ConversationMessage
           v-for="message in chatMessage.messages"
           :key="message.id"
           :isUser="message.isUser"
           :text="message.text"
         />
-        <p class="text-center font-heading text-sm font-light text-gray-dark">
-          WEDS 10:04 AM
-        </p>
       </div>
     </div>
     <div class="sticky bottom-0">

--- a/src/store/modules/chatMessages.js
+++ b/src/store/modules/chatMessages.js
@@ -14,10 +14,10 @@ const getters = {
         cm.messages = [...cm.messages].sort((a, b) => {
           const firstDate = new Date(a.receivedTime).getTime();
           const secondDate = new Date(b.receivedTime).getTime();
-          if (firstDate > secondDate) {
+          if (firstDate < secondDate) {
             return -1;
           }
-          if (firstDate < secondDate) {
+          if (firstDate > secondDate) {
             return 1;
           }
           return 0;


### PR DESCRIPTION
## [VCON-121](https://decdvirtualconcierge.atlassian.net/browse/VCON-121?atlOrigin=eyJpIjoiMmRhNmRiMDQ4MTI5NGJmNGE4YzY2ZDgxNGU1YjRmYTkiLCJwIjoiaiJ9) 

### Description
Reversed the order of the elements in the conversation window (chat messages + the timestamp), and then modified the store message getter so that the order of the messages returned from the store would also be reversed. This way, everything is in the correct order in terms of the DOM/html structure. 

In short, there should be absolutely no visual differences in this PR unless you remove all css, in which case the basic markup should be identical to the actual display order.

### Additional Notes
