### PR TITLE
Vcon 220 i18n routes

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -1,7 +1,7 @@
 import { createI18n } from 'vue-i18n'
 import messages from '@intlify/vite-plugin-vue-i18n/messages'
 
-export default  createI18n({
+export const i18n = createI18n({
   legacy: false,
   locale: 'en',
   globalInjection: true,

--- a/src/components/molecules/TheHeader.vue
+++ b/src/components/molecules/TheHeader.vue
@@ -22,9 +22,10 @@
             class="px-5 py-1 font-body underline text-blue-link"
             aria-label="Change language"
             tabindex="0"
+            @click="selectLanguage"
+            @keyup.enter="selectLanguage"
           >
-            Français
-            <!-- {language === "en" ? "English" : "Français"} -->
+            {{ $t("changeLanguage") }}
           </a>
         </div>
         <!-- end lang toggle desktop -->
@@ -52,9 +53,10 @@
               "
               aria-label="Change language"
               tabindex="0"
+              @click="selectLanguage"
+              @keyup.enter="selectLanguage"
             >
-              FR
-              <!-- {language === "en" ? "EN" : "FR"} -->
+              {{ $t("changeLanguageAbrv") }}
             </a>
           </div>
           <!-- end gc logo -->
@@ -134,6 +136,7 @@
 <script lang="ts">
 import Menu from "../atoms/Menu.vue";
 import Banner from "../atoms/Banner.vue";
+import { useI18n } from "vue-i18n";
 
 export default {
   name: "TheHeader",
@@ -142,7 +145,13 @@ export default {
     Banner,
   },
   setup() {
-    return {};
+    const i18n = useI18n();
+    function selectLanguage() {
+      i18n.locale.value == "en"
+        ? (i18n.locale.value = "fr")
+        : (i18n.locale.value = "en");
+    }
+    return { selectLanguage };
   },
 };
 </script>

--- a/src/components/molecules/TheHeader.vue
+++ b/src/components/molecules/TheHeader.vue
@@ -17,16 +17,15 @@
             justify-end
           "
         >
-          <a
+          <router-link
             id="lang-toggle-full"
             class="px-5 py-1 font-body underline text-blue-link"
             aria-label="Change language"
             tabindex="0"
-            @click="selectLanguage"
-            @keyup.enter="selectLanguage"
+            :to="changeLanguageTo == 'fr' ? '/' : '/fr'"
           >
             {{ $t("changeLanguage") }}
-          </a>
+          </router-link>
         </div>
         <!-- end lang toggle desktop -->
 
@@ -41,7 +40,7 @@
               src="../../assets/sig-blk-en.svg"
               alt="canada logo en"
             />
-            <a
+            <router-link
               id="lang-toggle-small"
               class="
                 sm:hidden
@@ -53,11 +52,10 @@
               "
               aria-label="Change language"
               tabindex="0"
-              @click="selectLanguage"
-              @keyup.enter="selectLanguage"
+              :to="changeLanguageTo == 'fr' ? '/' : '/fr'"
             >
               {{ $t("changeLanguageAbrv") }}
-            </a>
+            </router-link>
           </div>
           <!-- end gc logo -->
           <!-- start gc search bar -->
@@ -137,7 +135,7 @@
 import Menu from "../atoms/Menu.vue";
 import Banner from "../atoms/Banner.vue";
 import { useI18n } from "vue-i18n";
-
+import { computed } from "vue";
 export default {
   name: "TheHeader",
   components: {
@@ -145,13 +143,8 @@ export default {
     Banner,
   },
   setup() {
-    const i18n = useI18n();
-    function selectLanguage() {
-      i18n.locale.value === "en"
-        ? (i18n.locale.value = "fr")
-        : (i18n.locale.value = "en");
-    }
-    return { selectLanguage };
+    const changeLanguageTo = computed(() => useI18n().locale.value);
+    return { changeLanguageTo };
   },
 };
 </script>

--- a/src/components/molecules/TheHeader.vue
+++ b/src/components/molecules/TheHeader.vue
@@ -147,7 +147,7 @@ export default {
   setup() {
     const i18n = useI18n();
     function selectLanguage() {
-      i18n.locale.value == "en"
+      i18n.locale.value === "en"
         ? (i18n.locale.value = "fr")
         : (i18n.locale.value = "en");
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,3 +1,5 @@
 {
+  "changeLanguage": "Français",
+  "changeLanguageAbrv": "FR",
   "inbox": "Inbox"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,3 +1,5 @@
 {
+  "changeLanguage": "English",
+  "changeLanguageAbrv": "EN",
   "inbox": "FR: Inbox"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import { router } from "./router/index";
 import { store } from "./store/index";
-import i18n from "./../i18n";
+import { i18n } from "./../i18n";
 
 // Add tailwindcss
 import "./assets/styles/main.css";

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,15 +1,28 @@
 import { createRouter, createWebHistory } from "vue-router";
 import Home from "../views/Home.vue";
+import { i18n } from "./../../i18n";
 
 const NotFound = () => import("../views/NotFound.vue");
 
+const locales = "en|fr";
 export const router = createRouter({
   history: createWebHistory(),
   routes: [
     {
       path: "/",
-      name: "home",
+      name: Home,
       component: Home,
+    },
+    {
+      path: "/:lang(en|fr)",
+      component: Home,
+      children: [
+        {
+          path: "home",
+          name: "home",
+          component: Home,
+        },
+      ],
     },
     {
       path: "/404",
@@ -30,4 +43,16 @@ export const router = createRouter({
       return { top: 0 };
     }
   },
+});
+router.beforeEach((to, from, next) => {
+  // use the language from the routing param or default language
+  let language = to.params.lang;
+  if (!language) {
+    language = "en";
+  }
+
+  // set the current language for vuex-i18n. note that translation data
+  // for the language might need to be loaded first
+  i18n.global.locale.value = language;
+  next();
 });


### PR DESCRIPTION
## [VCON-220 Modify the routes/index.js file to allow for the i18n routes](https://decdvirtualconcierge.atlassian.net/browse/VCON-220?atlOrigin=eyJpIjoiYjNiMDNkNDI5NWViNDk0ZTk0ZDViZjUxMDgwYzI5NWMiLCJwIjoiaiJ9)

### Description
Added /en and /fr routes for English and french language
Language defaults to English
If language is not en or fr the router will throw 404 since it won't match on pattern

### Additional Notes
Home is the default page for paths /en & /fr
By default /en will only appear in url if specified in url
Only 3 translation keys have been added thus far
ChatBot and services will need lang passed for translations on their side