### PR TITLE
message header back button can focus

### DIFF
--- a/src/components/atoms/MessageHeader.vue
+++ b/src/components/atoms/MessageHeader.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="flex border-b border-gray-200 px-2 py-4">
-    <button @click="clickBack" aria-label="back to inbox">
+    <button
+      @click="clickBack"
+      aria-label="back to inbox"
+      @mouseover="setBackIcon('BackFocused')"
+      @mouseleave="setBackIcon('Back')"
+      @focus="setBackIcon('BackFocused')"
+      @focusout="setBackIcon('Back')"
+    >
       <img
         :src="icons[backIcon]"
         :alt="altText"
@@ -21,19 +28,23 @@
 <script>
 import icons from "../../assets/icons.js";
 import { useStore } from "vuex";
+import { ref } from "vue";
 export default {
   props: {
     imageName: String,
-    backIcon: String,
     altText: String,
     headerText: String,
   },
   setup() {
     const store = useStore();
+    let backIcon = ref("Back");
     function clickBack() {
       store.dispatch("inbox/closeInboxItem");
     }
-    return { clickBack, icons };
+    function setBackIcon(icon) {
+      backIcon.value = icon;
+    }
+    return { clickBack, setBackIcon, icons, backIcon };
   },
 };
 </script>

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -2,7 +2,6 @@
   <div class="w-full h-full flex flex-col text-gray-dark sm:relative">
     <div class="sticky top-0 opacity-95 bg-white md:opacity-100">
       <message-header
-        backIcon="Back"
         :imageName="chatMessage.senderIcon"
         :altText="chatMessage.senderIconAltText"
         :headerText="chatMessage.senderName"


### PR DESCRIPTION
## Bug: mobile message back button in header can now focus

### Description
When focus or mouse over of back button on mobile message header icon will change to focused state

### Additional Notes
You can tab to focus or mouse over