### PR TITLE
Added en to path on desktop

### DIFF
--- a/src/components/molecules/TheHeader.vue
+++ b/src/components/molecules/TheHeader.vue
@@ -22,7 +22,7 @@
             class="px-5 py-1 font-body underline text-blue-link"
             aria-label="Change language"
             tabindex="0"
-            :to="changeLanguageTo == 'fr' ? '/' : '/fr'"
+            :to="changeLanguageTo == 'fr' ? '/en' : '/fr'"
           >
             {{ $t("changeLanguage") }}
           </router-link>


### PR DESCRIPTION
## Bug where desktop language change to en sends to splash

### Description
Clicking English in TheHeader.vue will now take you to the English version of the app instead of the splash page