### PR TITLE
left aligned chat option/ removed center align chat messages

### DIFF
--- a/src/components/atoms/ChatOptionButton.vue
+++ b/src/components/atoms/ChatOptionButton.vue
@@ -11,6 +11,8 @@
       rounded-3xl
       bg-white
       hover:bg-gray-infolt
+      break-words
+      text-left
     "
     aria-label="Quick reply"
     @click="sendFromButton"

--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -5,7 +5,7 @@
         !isUser
           ? 'bg-gray-infolt mr-10'
           : 'bg-blue-primary text-white float-right ml-10 ',
-        ' p-3 rounded-3xl max-w-xs md:max-w-xl min-w-7/2r text-center break-words',
+        ' p-3 rounded-3xl max-w-xs md:max-w-xl min-w-7/2r break-words',
       ]"
     >
       {{ text }}


### PR DESCRIPTION
## [VCON-240](https://decdvirtualconcierge.atlassian.net/browse/VCON-240?atlOrigin=eyJpIjoiN2U1MjIyNjI2NjhmNGMzNzkxNGVhMDkwOTA3N2NkYTYiLCJwIjoiaiJ9) 

### Description
Left-aligned all the chat-related items in the conversation window, as Thomas requested.

### Additional Notes
I also added break-words to the chat options, in the unlikely event that something gets too long for it to be displayed in one line.