### PR TITLE
redundant div with app id has been terminated 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,5 @@
 <template>
-  <div id="app">
-    <router-view />
-  </div>
+  <router-view />
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## [VCON-112](https://decdvirtualconcierge.atlassian.net/browse/VCON-112?atlOrigin=eyJpIjoiMjNhMDY0N2I3N2MxNDUzNDg3OWI3NzE3Y2ExYzA4ZGYiLCJwIjoiaiJ9) 

### Description
I noticed that the div in App.vue wasn't actually needed since it seems like Vue makes the "#app" div on its own. This resolves a violation that was automatically detected with the Axe devtools extension. 

