### PR TITLE
added case for no messages in conversation

### DIFF
--- a/src/store/modules/inbox.js
+++ b/src/store/modules/inbox.js
@@ -16,18 +16,23 @@ const getters = {
       const lastMessage = messagesList[messagesList.length - 1];
 
       //dayRead will be unread if no value provided. The design currently accounts for only the weekday to be displayed
-      let dayRead = undefined;
+      let dayRead;
+      const lastReadDate = item.lastRead ? new Date(item.lastRead) : null;
+      const lastMessageReceivedDate = lastMessage?.receivedTime
+        ? new Date(lastMessage.receivedTime)
+        : null;
+
       if (
-        item.lastRead != null &&
-        lastMessage &&
-        new Date(item.lastRead) >= new Date(lastMessage.receivedTime)
+        lastReadDate !== null &&
+        lastMessageReceivedDate !== null &&
+        lastReadDate >= lastMessageReceivedDate
       ) {
-        dayRead = new Date(lastMessage.receivedTime).toLocaleDateString("En", {
+        dayRead = lastMessageReceivedDate.toLocaleDateString("En", {
           weekday: "short",
         });
-      } else if (item.lastRead !== null) {
+      } else if (lastReadDate !== null) {
         //to account for empty conversation/inbox item, so it doesn't remain always unread
-        dayRead = new Date(item.lastRead).toLocaleDateString("En", {
+        dayRead = lastReadDate.toLocaleDateString("En", {
           weekday: "short",
         });
       }

--- a/src/store/modules/inbox.js
+++ b/src/store/modules/inbox.js
@@ -1,6 +1,3 @@
-// Don't mind this import. I will use it in my next PR.
-// import InboxService from '../../services/inbox/inbox';
-
 const state = {
   selectedInboxItemId: 0,
   mobileDrawerOpen: false,
@@ -26,6 +23,11 @@ const getters = {
         new Date(item.lastRead) >= new Date(lastMessage.receivedTime)
       ) {
         dayRead = new Date(lastMessage.receivedTime).toLocaleDateString("En", {
+          weekday: "short",
+        });
+      } else if (item.lastRead !== null) {
+        //to account for empty conversation/inbox item, so it doesn't remain always unread
+        dayRead = new Date(item.lastRead).toLocaleDateString("En", {
           weekday: "short",
         });
       }


### PR DESCRIPTION
## [VCON-239](https://decdvirtualconcierge.atlassian.net/browse/VCON-239?atlOrigin=eyJpIjoiMWMwM2ExYTI1MWZiNGQ5N2E2MmM1YjAzMWY0YjY4MmUiLCJwIjoiaiJ9) (Link to issue on Jira)

### Description
The blue notification icon that indicates “your message is unread” now disappears on page load automatically since the conversation is auto-selected. This was caused by not checking if a conversation was empty before assigning it a read date, so a separate check has been added for the case in which an empty conversation has a read time but no messages.

