### PR TITLE
no tabbing to back button on desktop view/hidden

### DIFF
--- a/src/components/atoms/MessageHeader.vue
+++ b/src/components/atoms/MessageHeader.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="flex border-b border-gray-200 px-2 py-4">
     <button
+      ref="backBtn"
+      :tabindex="backBtnTabbable"
+      class="sm:hidden"
       @click="clickBack"
       aria-label="back to inbox"
       @mouseover="setBackIcon('BackFocused')"
@@ -11,7 +14,7 @@
       <img
         :src="icons[backIcon]"
         :alt="altText"
-        class="sm:hidden h-10 mt-auto w-10 mr-4"
+        class="h-10 mt-auto w-10 mr-4"
       />
     </button>
 
@@ -28,7 +31,7 @@
 <script>
 import icons from "../../assets/icons.js";
 import { useStore } from "vuex";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 export default {
   props: {
     imageName: String,
@@ -37,14 +40,30 @@ export default {
   },
   setup() {
     const store = useStore();
-    let backIcon = ref("Back");
+    const backIcon = ref("Back");
+    const backBtn = ref(null);
+    const backBtnTabbable = computed(() => {
+      if (backBtn.value === null) {
+        return -1; //doesn't really matter what we put here since it'll be updated
+      }
+      //if backBtn is hidden, don't allow for it to be tabbed to
+      return backBtn.value.style.display === "none" ? -1 : 0;
+    });
+
     function clickBack() {
       store.dispatch("inbox/closeInboxItem");
     }
     function setBackIcon(icon) {
       backIcon.value = icon;
     }
-    return { clickBack, setBackIcon, icons, backIcon };
+    return {
+      clickBack,
+      setBackIcon,
+      icons,
+      backIcon,
+      backBtn,
+      backBtnTabbable,
+    };
   },
 };
 </script>


### PR DESCRIPTION
## Probably should've had an issue on Jira about this, but this bothered me enough to stay in my mind regardless

### Description
The back button that shows up when you open the drawer for messages/a conversation is no longer tabbable when you're on desktop (and is therefore hidden). Pretty sure this relates to one ore more of the WCAG guidelines, I'll update this and look for the relevant guideline(s) if there are any.

