### PR TITLE
Inbox uses ul and li instead of divs

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -16,4 +16,7 @@
     div:focus {
         @apply ring-inset;
     }
+    li:focus {
+        @apply ring-inset;
+    }
 }

--- a/src/components/molecules/Inbox.vue
+++ b/src/components/molecules/Inbox.vue
@@ -19,14 +19,14 @@
     >
       {{ $t("inbox") }}
     </h1>
-    <div class="md:overflow-auto space-y-1" role="list">
+    <ul class="md:overflow-auto space-y-1" role="list">
       <inbox-item
         v-for="inboxItem in inboxItems"
         :key="inboxItem.id"
         :inboxItem="inboxItem"
         @select-inbox-item="selectInboxItem"
       />
-    </div>
+    </ul>
   </span>
 </template>
 

--- a/src/components/molecules/InboxItem.vue
+++ b/src/components/molecules/InboxItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <li
     role="listitem"
     tabindex="0"
     @click="selectInboxItem"
@@ -46,7 +46,7 @@
         v-bind:dayRead="inboxItem.dayRead"
       />
     </div>
-  </div>
+  </li>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## Inbox to use ul/li instead of divs

### Description
Instead of using divs within divs for the list of inbox items. Semantically we can use an ul(unorganised list) and create inbox items as li(list items). This is to help with accessibility

