### PR TITLE
Semantic markup for lists instead of divs

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -13,7 +13,7 @@
         @apply focus-visible:ring-1;
         @apply focus-visible:ring-black;
     }
-    div, li {
+    div, ul, li {
         @apply focus:ring-inset;
     }
     input {

--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[!isUser ? 'flex ' : '', 'pl-10 relative']">
+  <li :class="[!isUser ? 'flex ' : '', 'pl-10 relative']">
     <p
       :class="[
         !isUser
@@ -17,7 +17,7 @@
       :alt="senderIconAltText"
       class="h-6 w-10 absolute left-0 bottom-0"
     />
-  </div>
+  </li>
 </template>
 <script>
 import icons from "../../assets/icons.js";

--- a/src/components/molecules/MessageCard.vue
+++ b/src/components/molecules/MessageCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-white p-6 space-y-3 text-gray-dark">
+  <li class="bg-white p-6 space-y-3 text-gray-dark">
     <span class="uppercase text-sm font-heading font-light">{{
       timestamp
     }}</span>
@@ -7,7 +7,7 @@
     <p class="font-normal font-body text-lg whitespace-pre-line">
       {{ paragraphs }}
     </p>
-  </div>
+  </li>
 </template>
 
 <script>

--- a/src/components/molecules/MessageList.vue
+++ b/src/components/molecules/MessageList.vue
@@ -6,7 +6,7 @@
       :altText="mailObject.senderIconAltText"
       :headerText="mailObject.senderName"
     />
-    <div
+    <ul
       class="flex bg-gray-infolt flex-col p-6 space-y-6 overflow-auto"
       tabindex="0"
     >
@@ -17,7 +17,7 @@
         :title="email.messageTitle"
         :paragraphs="email.messageBody"
       />
-    </div>
+    </ul>
   </div>
 </template>
 

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -8,7 +8,7 @@
       />
     </div>
     <div class="flex h-full overflow-auto">
-      <div
+      <ul
         class="
           w-full
           space-y-2 space-y-reverse
@@ -21,9 +21,11 @@
         "
         tabindex="0"
       >
-        <p class="text-center font-heading text-sm font-light text-gray-dark">
-          {{ $t("messageTime") }}
-        </p>
+        <li>
+          <p class="text-center font-heading text-sm font-light text-gray-dark">
+            {{ $t("messageTime") }}
+          </p>
+        </li>
         <ConversationMessage
           v-for="(message, index) in chatMessage.messages"
           :key="message.id"
@@ -33,7 +35,7 @@
           :senderIconAltText="chatMessage.senderIconAltText"
           :isLastMessage="index === chatMessage.messages.length - 1"
         />
-      </div>
+      </ul>
     </div>
     <div class="sticky bottom-0">
       <!-- The logic on how the buttonOptions are passed as props will


### PR DESCRIPTION
## Semantic markup for lists instead of divs

### Description
Both the chatbot conversation and email messages now use ul and li tags instead of divs for accessibility reasons