### PR TITLE
Get rid of useless logic now that the text input has no focus styles 

### DIFF
--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -3,14 +3,15 @@
     ref="input"
     type="text"
     :placeholder="$t('writeSomething')"
-    :class="
-      'w-full border-t border-b border-gray-200 placeholder-gray-light p-3 bg-clip-padding ' +
-      inputFocusClass
+    class="
+      w-full
+      border-t border-b border-gray-200
+      placeholder-gray-light
+      p-3
+      bg-clip-padding
     "
     v-model="text"
     :aria-label="$t('writeSomething')"
-    @focus="changeInputFocusStyles($event, ' ')"
-    @mousedown="changeInputFocusStyles($event, ' focus:ring-transparent')"
     @keyup.enter="sendText"
     @input="checkSendBtnActive"
   />
@@ -56,7 +57,6 @@ export default {
   },
   emits: ["add-message"],
   setup(_, context) {
-    const inputFocusClass = ref("");
     const text = ref("");
     const sendMsgBtnTabIndex = ref(-1); //should be inactive as there's no input text at the start
     const iconState = ref("SendInactive");
@@ -83,14 +83,6 @@ export default {
         text.value === "" ? "SendInactive" : "SendActiveFocused";
     }
 
-    function changeInputFocusStyles(event, focusClass) {
-      if (event.type === "mousedown") {
-        event.preventDefault();
-        event.target.focus();
-      }
-      inputFocusClass.value = " " + focusClass;
-    }
-
     function checkSendBtnActive() {
       let textEmpty = text.value === "";
       sendMsgBtnTabIndex.value = textEmpty ? -1 : 0; //the send button will be untabbable if there's no text
@@ -106,8 +98,6 @@ export default {
       sendBtnText,
       onSendBtnFocus,
       checkSendBtnActive,
-      changeInputFocusStyles,
-      inputFocusClass,
     };
   },
 };


### PR DESCRIPTION
### Description
Pretty much what the title says, now that we don't use focus styles for the text inputs, we can get rid of the logic for checking if there's a click on them and if it was focused on by tabbing. Functionally changes nothing, just cleans up the code a little.
