### PR TITLE
Bubble chat animation partial fix

### DIFF
--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -3,8 +3,13 @@
     <p
       :class="[
         !isUser
-          ? 'bg-gray-infolt mr-10 botMessage'
-          : 'bg-blue-primary text-white float-right ml-10 userMessage',
+          ? 'bg-gray-infolt mr-10'
+          : 'bg-blue-primary text-white float-right ml-10',
+        isLastMessage && isUser
+          ? 'userMessage'
+          : isLastMessage
+          ? 'botMessage'
+          : '',
         ' p-3 rounded-3xl max-w-xs md:max-w-xl min-w-7/2r break-words',
       ]"
     >


### PR DESCRIPTION
### Description
After sending messages to the chatbot, swapping from the chatbot to job banks reactivates all animations.
this PR makes it so that only the last message sent/received has the animation.

### Additional Notes
 - I am still working on removing all animation once it has been sent/recieved but for now, this is better.
