### PR TITLE
Bug Fix: Conversation overlapping header in conversation window on mobile

### DIFF
--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full h-full flex flex-col text-gray-dark sm:relative">
-    <div class="sticky top-0 opacity-95 bg-white md:opacity-100">
+    <div class="sticky top-0 opacity-95 bg-white md:opacity-100 z-10">
       <message-header
         :imageName="chatMessage.senderIcon"
         :altText="chatMessage.senderIconAltText"


### PR DESCRIPTION
## Conversation overlapping header in conversation window on mobile

### Description
Unable to interact with header to go back in mobile when too many messages are present. This is due to the conversation expanding over-top of the header.

### Additional Notes
Adjusted header z index to 10

### Test
1. Open VA conversation in mobile app view
2. Add enough messages to fill screen
3. Header should have faded messages behind it
4. Click the back arrow should return to inbox screen