### PR TITLE
Fixing overflow-x on mobile.

### DIFF
--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full h-full flex flex-col text-gray-dark sm:relative">
-    <div class="sticky top-0 opacity-95 bg-white md:opacity-100">
+    <div class="sticky top-0 opacity-95 z-10 bg-white md:opacity-100">
       <message-header
         :imageName="chatMessage.senderIcon"
         :altText="chatMessage.senderIconAltText"

--- a/src/components/organisms/MessagesContainer.vue
+++ b/src/components/organisms/MessagesContainer.vue
@@ -18,7 +18,7 @@
     <div
       :class="[
       isMobileDrawerOpen ? 'left-0' : 'left-full', 
-      'inbox-transition absolute bg-white top-0 min-h-screen w-screen sm:left-0 sm:min-h-0 sm:h-vh-3/5 sm:relative sm:flex-auto sm:block sm:border sm:border-gray xl:h-vh-2/3',
+      'inbox-transition fixed bg-white top-0 bottom-0 w-screen sm:left-0 sm:min-h-0 sm:h-vh-3/5 sm:relative sm:flex-auto sm:block sm:border sm:border-gray xl:h-vh-2/3',
       ]"
     >
       <ConversationWindow v-if="inboxItemType === 'chat'" />


### PR DESCRIPTION
### Description
This PR fixes the overflow-x that the mobile version had.

### Additional Notes

- test in multiple browsers and desktop/mobile version as well.
- I also threw in the z-10 index for the header in the chatbot so that no messages would overlap on top of the header.
