### PR TITLE
make inbox items scroll again

### DIFF
--- a/src/components/molecules/Inbox.vue
+++ b/src/components/molecules/Inbox.vue
@@ -4,14 +4,14 @@
     <div class="px-3 pt-6 pb-3">
       <div class="bg-gray-infolt h-10 w-2/3 animate-pulse"></div>
     </div>
-    <div class="md:overflow-auto space-y-1" role="list">
+    <div class="sm:overflow-auto overflow-y space-y-1" role="list">
       <!-- Empty inbox items -->
       <inbox-item :inboxItem="{}" />
       <inbox-item :inboxItem="{}" />
     </div>
   </span>
   <!-- Loaded State -->
-  <span v-else>
+  <div v-else class="w-full sm:h-vh-3/5 xl:h-vh-2/3 flex flex-col">
     <h1
       id="inbox-header"
       class="font-heading font-bold text-4xl px-3 pt-6 pb-3"
@@ -19,7 +19,7 @@
     >
       {{ $t("inbox") }}
     </h1>
-    <ul class="md:overflow-auto space-y-1" role="list">
+    <ul class="sm:overflow-auto space-y-1" role="list">
       <inbox-item
         v-for="inboxItem in inboxItems"
         :key="inboxItem.id"
@@ -27,7 +27,7 @@
         @select-inbox-item="selectInboxItem"
       />
     </ul>
-  </span>
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/components/molecules/Inbox.vue
+++ b/src/components/molecules/Inbox.vue
@@ -4,7 +4,7 @@
     <div class="px-3 pt-6 pb-3">
       <div class="bg-gray-infolt h-10 w-2/3 animate-pulse"></div>
     </div>
-    <div class="sm:overflow-auto overflow-y space-y-1" role="list">
+    <div class="sm:overflow-auto space-y-1" role="list">
       <!-- Empty inbox items -->
       <inbox-item :inboxItem="{}" />
       <inbox-item :inboxItem="{}" />

--- a/src/components/molecules/InboxItem.vue
+++ b/src/components/molecules/InboxItem.vue
@@ -7,7 +7,7 @@
     :class="[
       inboxItem.selected ? 'focus:bg-blue-selected rounded-none' : '',
       inboxItem.id ? '' : 'bg-gray-infolt animate-pulse',
-      'flex items-center w-full h-16 md:h-20 rounded focus:border-black focus:bg-gray-infolt active:bg-blue-selected hover:bg-gray-infolt cursor-pointer ',
+      'flex items-center w-full h-16 md:h-20 rounded focus:bg-gray-infolt active:bg-blue-selected hover:bg-gray-infolt cursor-pointer ',
     ]"
   >
     <div class="p-1">


### PR DESCRIPTION
### Description
![image](https://user-images.githubusercontent.com/45071113/127213995-050e288f-1fca-4da6-b598-4f19fd732711.png)
While doing stuff to do with text resizing, I noticed that the French version of the site at 200% zoom made the inbox items clip like in the picture above. So, I went through some old PRs, copied the formatting that had the scrollbar working in similar cases, and then removed as much of it as possible while keeping functionality intact. The CSS classes might be able to be reduced even further, but this seemed like enough. 

TL;DR scrolling fixed for inbox items. This won't be noticed unless you change some settings in-browser.

What it looks like in French mode + 200% zoom now:
![image](https://user-images.githubusercontent.com/45071113/127214698-7eb8df63-777a-48dd-a2a6-4b7075a80265.png)

### Additional notes
Also changed it so that the inbox list would overflow-scroll automatically starting from small screen sizes (since that's when we switch to the desktop view now).
Also removed a redundant class for making the inbox items get a black focus border (which they have by default now).