### PR TITLE
use disable instead of tabindex

### DIFF
--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -30,7 +30,7 @@
       <button
         class="cursor-pointer absolute right-0 top-0"
         :aria-label="$t('sendMessage')"
-        :tabindex="sendMsgBtnTabIndex"
+        :disabled="isDisabled"
         @click="sendText"
         @focus="onSendBtnFocus"
         @mouseover="onSendBtnFocus"
@@ -64,7 +64,7 @@ export default {
   emits: ["add-message"],
   setup(_, context) {
     const text = ref("");
-    const sendMsgBtnTabIndex = ref(-1); //should be inactive as there's no input text at the start
+    const isDisabled = ref(true); //should be inactive as there's no input text at the start
     const iconState = ref("SendInactive");
 
     //this ref are reassigned to their respective components on mounting
@@ -90,12 +90,11 @@ export default {
     }
 
     function checkSendBtnActive() {
-      let textEmpty = text.value === "";
-      sendMsgBtnTabIndex.value = textEmpty ? -1 : 0; //the send button will be untabbable if there's no text
-      iconState.value = textEmpty ? "SendInactive" : "SendActive";
+      isDisabled.value = text.value === ""; //the send button will be untabbable if there's no text
+      iconState.value = isDisabled.value ? "SendInactive" : "SendActive";
     }
     return {
-      sendMsgBtnTabIndex,
+      isDisabled,
       input,
       text,
       icons,


### PR DESCRIPTION
## Not sure which WCAG item this applies to, maybe [4.1.1 Parsing](https://decdvirtualconcierge.atlassian.net/browse/VCON-144?atlOrigin=eyJpIjoiMjg4OTAxMTY2NTVkNDc2YjhkYTM3MzUxMGM4OGU3MTgiLCJwIjoiaiJ9)

### Description
Instead of disabling the send button by setting tabindex to 0, I used the disable attribute. 