### PR TITLE
Added message card tests

### DIFF
--- a/__tests__/components/molecules/MessageCard.spec.js
+++ b/__tests__/components/molecules/MessageCard.spec.js
@@ -1,0 +1,32 @@
+import { shallowMount } from "@vue/test-utils";
+import { i18n } from "../../../i18n";
+import MessageCard from "../../../src/components/molecules/MessageCard";
+
+describe("MessageCard component", () => {
+  let wrapper;
+
+  beforeAll(() => {
+    wrapper = shallowMount(MessageCard, {
+      global: {
+        plugins: [i18n],
+      },
+      props: {
+        timestamp: "test timestamp",
+        title: "test title",
+        paragraphs: "test paragraphs",
+      },
+    });
+  });
+
+  it("Check for timestamp text in MessageCard", () => {
+    expect(wrapper.text()).toContain("test timestamp");
+  });
+
+  it("Check for title text in MessageCard", () => {
+    expect(wrapper.text()).toContain("test title");
+  });
+
+  it("Check for paragraphs text in MessageCard", () => {
+    expect(wrapper.text()).toContain("test paragraphs");
+  });
+});


### PR DESCRIPTION
## [VCON-280](https://decdvirtualconcierge.atlassian.net/browse/VCON-280?atlOrigin=eyJpIjoiZTQwYjRhOWQ2YWQyNDcxMDgyODBlM2EyYWNiZjUzNWMiLCJwIjoiaiJ9)

### Description
MessageCard test portion of VCON-280 using shallow mount and i18n plugin
Please let me know if there are other opportunities to create more robust tests

### Additional Notes
Props added and checked to see if rendered anywhere on the page