### PR TITLE
fix skip nav "pushing" page downwards

### DIFF
--- a/src/components/molecules/Inbox.vue
+++ b/src/components/molecules/Inbox.vue
@@ -14,7 +14,7 @@
   <div v-else class="w-full sm:h-vh-3/5 xl:h-vh-2/3 flex flex-col">
     <h1
       id="inbox-header"
-      class="font-heading font-bold text-4xl px-3 pt-6 pb-3"
+      class="font-heading font-bold text-4xl px-3 pt-6 pb-3 focus:ring-inset"
       @blur="$event.target.tabIndex = -1"
     >
       {{ $t("inbox") }}

--- a/src/components/molecules/TheSkipNav.vue
+++ b/src/components/molecules/TheSkipNav.vue
@@ -1,12 +1,25 @@
 <template>
-  <nav>
+  <nav class="relative">
     <!-- Site Accessibility Navigation -->
     <ul
       class="sr-only focus-within:not-sr-only text-center"
       :aria-label="$t('skipNavLink')"
     >
       <li
-        class="w-max bg-blue-deep text-white mt-2 p-2 rounded inline-block"
+        class="
+          transform
+          -translate-x-1/2
+          absolute
+          left-1/2
+          top-0
+          w-max
+          bg-blue-deep
+          text-white
+          mt-2
+          p-2
+          rounded
+          block
+        "
         @click="toMain"
       >
         <a href="#index-header">{{ $t("skipToMain") }}</a>


### PR DESCRIPTION
## No Jira issue, mentioned by Neil 
![image](https://user-images.githubusercontent.com/45071113/128021797-7fa3fc74-77b7-4512-bf48-221cf7210928.png)

### Description
Changed the skip nav so it'd have absolute positioning, therefore it no longer "pushes" the page as it doesn't appear on top of the header. 

#### Then (Note the whitespace): 
![image](https://user-images.githubusercontent.com/45071113/128022210-f603d6dc-2d20-4082-b603-6c8af604b72d.png)

#### Now:
![image](https://user-images.githubusercontent.com/45071113/128022364-21498a65-fbdf-4d58-b355-051d46ee5430.png)

#### Canada.ca comparison:
![image](https://user-images.githubusercontent.com/45071113/128022451-46949e27-c96f-4c4b-a378-4f1e9fd71256.png)

### Additional Notes
Took the liberty of fixing up the inbox's focus style, part of the outline wasn't visible so I used an inset ring instead.
Also note that due to the absolute positioning, at certain screen sizes the skip nav will go over the government logo, BUT canada.ca also has that behaviour, so it's probably irrelevant. 
![image](https://user-images.githubusercontent.com/45071113/128022577-3de1f64d-6acf-4cca-a067-89e52ffb700b.png)
