### PR TITLE
fixed inbox item states

### DIFF
--- a/src/components/molecules/InboxItem.vue
+++ b/src/components/molecules/InboxItem.vue
@@ -5,9 +5,11 @@
     @click="selectInboxItem"
     @keyup.enter="selectInboxItem"
     :class="[
-      inboxItem.selected ? 'focus:bg-blue-selected rounded-none' : '',
+      inboxItem.selected
+        ? 'bg-blue-selected rounded-none'
+        : 'focus:bg-gray-infolt hover:bg-gray-infolt ',
       inboxItem.id ? '' : 'bg-gray-infolt animate-pulse',
-      'flex items-center w-full h-16 md:h-20 rounded focus:bg-gray-infolt active:bg-blue-selected hover:bg-gray-infolt cursor-pointer ',
+      'flex items-center w-full h-16 md:h-20 rounded active:bg-blue-selected cursor-pointer',
     ]"
   >
     <div class="p-1">


### PR DESCRIPTION
## [VCON-272](https://decdvirtualconcierge.atlassian.net/browse/VCON-272) 

### Description
Basically had these things in mind:
- selected state stays when clicking away
- selected state appears on the default selected item
- hover and focus doesn't change an inbox item that's already selected

### Hoy Seal of Approval 
![image](https://user-images.githubusercontent.com/45071113/128033380-73b3390f-e9d6-4af0-9858-2937073bc14c.png)
