### PR TITLE
properly hide drawer items when not in view

### DIFF
--- a/src/components/molecules/MessageList.vue
+++ b/src/components/molecules/MessageList.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="w-full h-full flex flex-col">
+  <div
+    :class="[
+      'w-full h-full sm:flex flex-col',
+      isMobileDrawerOpen ? 'flex' : 'hidden',
+    ]"
+  >
     <message-header
       backIcon="Back"
       :imageName="mailObject.senderIcon"
@@ -43,6 +48,10 @@ export default {
         selectedInboxItemId
       )
     );
+
+    const isMobileDrawerOpen = computed(
+      () => store.getters["inbox/isMobileDrawerOpen"]
+    );
     //creates a timestamp with js's default date methods
     const createTimestamp = (dateString) => {
       return new Date(dateString).toLocaleDateString(i18n.global.locale.value, {
@@ -56,6 +65,7 @@ export default {
     return {
       mailObject,
       createTimestamp,
+      isMobileDrawerOpen,
       icons,
     };
   },

--- a/src/components/molecules/MessageList.vue
+++ b/src/components/molecules/MessageList.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    :class="[
-      'w-full h-full sm:flex flex-col',
-      isMobileDrawerOpen ? 'flex' : 'hidden',
-    ]"
-  >
+  <div class="w-full h-full flex flex-col" v-show="isMobileDrawerOpen">
     <message-header
       backIcon="Back"
       :imageName="mailObject.senderIcon"

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -1,9 +1,7 @@
 <template>
   <div
-    :class="[
-      'w-full h-full flex flex-col text-gray-dark sm:relative',
-      isMobileDrawerOpen ? 'flex' : 'hidden',
-    ]"
+    class="w-full h-full flex flex-col text-gray-dark sm:relative"
+    v-show="isMobileDrawerOpen"
   >
     <div class="sticky top-0 opacity-95 z-10 bg-white md:opacity-100">
       <message-header

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="w-full h-full flex flex-col text-gray-dark sm:relative">
+  <div
+    :class="[
+      'w-full h-full flex flex-col text-gray-dark sm:relative',
+      isMobileDrawerOpen ? 'flex' : 'hidden',
+    ]"
+  >
     <div class="sticky top-0 opacity-95 z-10 bg-white md:opacity-100">
       <message-header
         :imageName="chatMessage.senderIcon"
@@ -74,6 +79,9 @@ export default {
         selectedInboxItemId
       )
     );
+    const isMobileDrawerOpen = computed(
+      () => store.getters["inbox/isMobileDrawerOpen"]
+    );
 
     function sendChatMessage(msg) {
       const newMessage = {
@@ -86,6 +94,7 @@ export default {
     return {
       chatMessage,
       sendChatMessage,
+      isMobileDrawerOpen,
       icons,
     };
   },


### PR DESCRIPTION
## [VCON-142](https://decdvirtualconcierge.atlassian.net/browse/VCON-142?atlOrigin=eyJpIjoiZjEwNDVhNjA3ODBlNDYzNmJkODQ1M2Y2ZTRiMTg5YjkiLCJwIjoiaiJ9) 

### Description
Focus wasn't visible due to drawer elements being tabbable when the drawer wasn't in view, so I used the hidden class on the drawers when they weren't in view so that way they weren't tabbable. This should also prevent screenreaders from reading the drawer item contents. 

### Additional Notes
Not sure if this actually relates to VCON-142 (WCAG 2.4.7 Focus visible) or if there's a different issue for elements that aren't in view that can still receive focus. Regardless, issue resolved.
I tried to do the `isMobileDrawerOpen ? 'flex' : 'hidden'` thing in the MessagesContainer as opposed to the individual ConversationWindow and MessageList components, but it also removed the sliding animation entirely. I imagine there's a better way to do this using different animations and such, but I know very little about animation with css/tailwind. Feel free to try out something like that yourself. 