### PR TITLE
VCON-Added tests to inbox store

### DIFF
--- a/__tests__/store/modules/inbox.spec.js
+++ b/__tests__/store/modules/inbox.spec.js
@@ -89,6 +89,7 @@ describe("inbox actions", () => {
   it("selectDefaultInboxItem", () => {
     store.dispatch("inbox/selectDefaultInboxItem", 5);
 
+    //Test argument being passed to mutation correctly
     const updateSelectedInboxItemIdArgs =
       mockedMutations.updateSelectedInboxItemId.mock.calls[0][1];
     expect(updateSelectedInboxItemIdArgs).toBe(5);
@@ -97,6 +98,7 @@ describe("inbox actions", () => {
   it("selectInboxItem", () => {
     store.dispatch("inbox/selectInboxItem", 5);
 
+    //Test argument being passed to mutation correctly
     const updateSelectedInboxItemIdArgs =
       mockedMutations.updateSelectedInboxItemId.mock.calls[0][1];
     expect(updateSelectedInboxItemIdArgs).toBe(5);
@@ -109,6 +111,7 @@ describe("inbox actions", () => {
   it("closeInboxItem", () => {
     store.dispatch("inbox/closeInboxItem");
 
+    //Test argument being passed to mutation correctly
     const updateMobileDrawerOpenArgs =
       mockedMutations.updateMobileDrawerOpen.mock.calls[0][1];
     expect(updateMobileDrawerOpenArgs).toBe(false);

--- a/__tests__/store/modules/inbox.spec.js
+++ b/__tests__/store/modules/inbox.spec.js
@@ -1,0 +1,134 @@
+import inbox from "../../../src/store/modules/inbox";
+import { createStore, useStore } from "vuex";
+import chatMessages from "../../../src/store/modules/chatMessages";
+jest.mock("../../../src/store/modules/chatMessages");
+import emails from "../../../src/store/modules/emails";
+jest.mock("../../../src/store/modules/emails");
+
+describe("inbox getters", () => {
+  it("getInboxItems", () => {
+    const store = createStore({
+      modules: {
+        inbox,
+        emails,
+        chatMessages,
+      },
+    });
+    const inboxItems = store.getters["inbox/getInboxItems"];
+    expect(inboxItems.length).toBe(2);
+    expect(inboxItems[0].type).toBe("chat");
+    expect(inboxItems[1].type).toBe("email");
+  });
+  it("getSelectedInboxItem", () => {
+    const store = createStore({
+      modules: {
+        inbox,
+        emails,
+        chatMessages,
+      },
+    });
+    //get inbox item id of 1 which is the mocked chat
+    store.state.inbox.selectedInboxItemId = 1;
+
+    const inboxItem = store.getters["inbox/getSelectedInboxItem"];
+    expect(inboxItem.selected).toBe(true);
+    expect(inboxItem.type).toBe("chat");
+  });
+  it("getSelectedInboxItemType", () => {
+    const store = createStore({
+      modules: {
+        inbox,
+        emails,
+        chatMessages,
+      },
+    });
+    store.state.inbox.selectedInboxItemId = 1;
+
+    const inboxItemType = store.getters["inbox/getSelectedInboxItemType"];
+    expect(inboxItemType).toBe("chat");
+  });
+  it("isMobileDrawerOpen", () => {
+    let state = {
+      mobileDrawerOpen: true,
+    };
+    expect(inbox.getters.isMobileDrawerOpen(state)).toBe(true);
+    state = {
+      mobileDrawerOpen: false,
+    };
+    expect(inbox.getters.isMobileDrawerOpen(state)).toBe(false);
+  });
+  it("isLoaded", () => {
+    const store = createStore({
+      modules: {
+        inbox,
+        emails,
+        chatMessages,
+      },
+    });
+    const loaded = store.getters["inbox/isLoaded"];
+    expect(loaded).toBe(true);
+  });
+});
+
+describe("inbox mutations", () => {
+  it("updateSelectedInboxItemId", () => {
+    const state = { selectedInboxItemId: 0 };
+    inbox.mutations.updateSelectedInboxItemId(state, 5);
+
+    expect(state.selectedInboxItemId).toBe(5);
+  });
+  it("updateMobileDrawerOpen", () => {
+    const state = { mobileDrawerOpen: false };
+    inbox.mutations.updateMobileDrawerOpen(state, true);
+
+    expect(state.mobileDrawerOpen).toBe(true);
+  });
+});
+
+describe("inbox actions", () => {
+  let store;
+  let mockedMutations;
+  beforeEach(() => {
+    mockedMutations = {
+      updateSelectedInboxItemId: jest.fn(),
+      updateMobileDrawerOpen: jest.fn(),
+    };
+    store = createStore({
+      modules: {
+        inbox: {
+          namespaced: true,
+          actions: inbox.actions,
+          mutations: mockedMutations,
+        },
+      },
+    });
+  });
+  it("selectDefaultInboxItem", () => {
+    store.dispatch("inbox/selectDefaultInboxItem", 5);
+
+    const updateSelectedInboxItemIdArgs =
+      mockedMutations.updateSelectedInboxItemId.mock.calls[0][1];
+    expect(updateSelectedInboxItemIdArgs).toBe(5);
+    expect(mockedMutations.updateSelectedInboxItemId).toHaveBeenCalledTimes(1);
+  });
+  it("selectInboxItem", () => {
+    store.dispatch("inbox/selectInboxItem", 5);
+
+    const updateSelectedInboxItemIdArgs =
+      mockedMutations.updateSelectedInboxItemId.mock.calls[0][1];
+    expect(updateSelectedInboxItemIdArgs).toBe(5);
+    const updateMobileDrawerOpenArgs =
+      mockedMutations.updateMobileDrawerOpen.mock.calls[0][1];
+    expect(updateMobileDrawerOpenArgs).toBe(true);
+    expect(mockedMutations.updateSelectedInboxItemId).toHaveBeenCalledTimes(1);
+    expect(mockedMutations.updateMobileDrawerOpen).toHaveBeenCalledTimes(1);
+  });
+  it("closeInboxItem", () => {
+    store.dispatch("inbox/closeInboxItem");
+
+    const updateMobileDrawerOpenArgs =
+      mockedMutations.updateMobileDrawerOpen.mock.calls[0][1];
+    expect(updateMobileDrawerOpenArgs).toBe(false);
+    expect(mockedMutations.updateMobileDrawerOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/store/modules/inbox.spec.js
+++ b/__tests__/store/modules/inbox.spec.js
@@ -6,27 +6,24 @@ import emails from "../../../src/store/modules/emails";
 jest.mock("../../../src/store/modules/emails");
 
 describe("inbox getters", () => {
-  it("getInboxItems", () => {
-    const store = createStore({
+  let store;
+  beforeAll(() => {
+    store = createStore({
       modules: {
-        inbox,
-        emails,
         chatMessages,
+        emails,
+        inbox,
       },
     });
+  });
+
+  it("getInboxItems", () => {
     const inboxItems = store.getters["inbox/getInboxItems"];
     expect(inboxItems.length).toBe(2);
     expect(inboxItems[0].type).toBe("chat");
     expect(inboxItems[1].type).toBe("email");
   });
   it("getSelectedInboxItem", () => {
-    const store = createStore({
-      modules: {
-        inbox,
-        emails,
-        chatMessages,
-      },
-    });
     //get inbox item id of 1 which is the mocked chat
     store.state.inbox.selectedInboxItemId = 1;
 
@@ -35,13 +32,6 @@ describe("inbox getters", () => {
     expect(inboxItem.type).toBe("chat");
   });
   it("getSelectedInboxItemType", () => {
-    const store = createStore({
-      modules: {
-        inbox,
-        emails,
-        chatMessages,
-      },
-    });
     store.state.inbox.selectedInboxItemId = 1;
 
     const inboxItemType = store.getters["inbox/getSelectedInboxItemType"];
@@ -58,13 +48,6 @@ describe("inbox getters", () => {
     expect(inbox.getters.isMobileDrawerOpen(state)).toBe(false);
   });
   it("isLoaded", () => {
-    const store = createStore({
-      modules: {
-        inbox,
-        emails,
-        chatMessages,
-      },
-    });
     const loaded = store.getters["inbox/isLoaded"];
     expect(loaded).toBe(true);
   });

--- a/src/store/modules/__mocks__/chatMessages.js
+++ b/src/store/modules/__mocks__/chatMessages.js
@@ -1,3 +1,7 @@
+const state = {
+  loaded: true,
+};
+
 const getters = {
   getChatMessageByIdOrderedByMessagesDate: (state, getters) => (id) => {
     return {
@@ -11,6 +15,23 @@ const getters = {
         senderIconAltText: "test alt text",
       },
     };
+  },
+  getAllChatMessages(state) {
+    return [
+      {
+        id: 1,
+        messages: [
+          {
+            id: 1,
+            receivedTime: new Date(2018, 11, 24, 10, 33, 30, 0),
+            isUser: true,
+            text: "test message text",
+            senderIcon: "test icon",
+            senderIconAltText: "test alt text",
+          },
+        ],
+      },
+    ];
   },
   isLoaded() {
     return true;
@@ -28,6 +49,7 @@ const actions = {
 
 export default {
   namespaced: true,
+  state,
   getters,
   actions,
 };

--- a/src/store/modules/__mocks__/emails.js
+++ b/src/store/modules/__mocks__/emails.js
@@ -1,4 +1,22 @@
+const state = {
+  loaded: true,
+};
+
 const getters = {
+  getMailObject(state) {
+    return [
+      {
+        emails: [
+          {
+            id: 2,
+            messageTitle: "test title",
+            messageBody: "test body",
+            receivedTime: Date.now(),
+          },
+        ],
+      },
+    ];
+  },
   isLoaded() {
     return true;
   },
@@ -6,5 +24,6 @@ const getters = {
 
 export default {
   namespaced: true,
+  state,
   getters,
 };


### PR DESCRIPTION
## [VCON-168](https://decdvirtualconcierge.atlassian.net/browse/VCON-168?atlOrigin=eyJpIjoiZTk1N2JjZDliM2QwNDQ2NzliMjE2NjI5YjJkZjg3M2EiLCJwIjoiaiJ9)

### Description
Unit tests added to Vuex state for inbox

### Additional Notes
Calls to chatMessages and emails have been mocked
Inbox getters are a bit wonky as I had to use getters from chatMessages for a decent amount of them so they follow what is in the mock files