### PR TITLE
removed ReadNotification's id values entirely

### DIFF
--- a/__tests__/components/atoms/ReadNotification.spec.js
+++ b/__tests__/components/atoms/ReadNotification.spec.js
@@ -2,28 +2,19 @@ import { mount } from "@vue/test-utils";
 import ReadNotification from "../../../src/components/atoms/ReadNotification";
 
 describe("ReadNotification component", () => {
+  const dayReadProp = "Monday";
   it("ensures that the read notification is displayed", () => {
     const wrapper = mount(ReadNotification, {
       props: {
-        dayRead: "Monday",
+        dayRead: dayReadProp,
       },
     });
-    expect(wrapper.text()).toContain("Monday");
-  });
-  // false by default (not read)
-  it("ensures ReadNotification icon is shown (message has not been read)", () => {
-    const wrapper = mount(ReadNotification);
-    expect(wrapper.find("p").exists()).toBe(false); //unread notification has no text/ <p> tag
+    expect(wrapper.text()).toContain(dayReadProp); //check that prop is displayed
   });
 
-  it("ensures dayRead date is shown (message has been read)", () => {
-    const wrapper = mount(ReadNotification, {
-      data() {
-        return {
-          dayRead: true,
-        };
-      },
-    });
-    expect(wrapper.find("p").exists()).toBe(true); //likewise, the day the message was read should appear here.
+  // false/empty by default (not read)
+  it("ensures ReadNotification icon is shown (message has not been read)", () => {
+    const wrapper = mount(ReadNotification);
+    expect(wrapper.text()).toBe(""); //unread notification has no text
   });
 });

--- a/__tests__/components/atoms/ReadNotification.spec.js
+++ b/__tests__/components/atoms/ReadNotification.spec.js
@@ -13,7 +13,7 @@ describe("ReadNotification component", () => {
   // false by default (not read)
   it("ensures ReadNotification icon is shown (message has not been read)", () => {
     const wrapper = mount(ReadNotification);
-    expect(wrapper.find("#not-read").exists()).toBe(true);
+    expect(wrapper.find("p").exists()).toBe(false); //unread notification has no text/ <p> tag
   });
 
   it("ensures dayRead date is shown (message has been read)", () => {
@@ -24,6 +24,6 @@ describe("ReadNotification component", () => {
         };
       },
     });
-    expect(wrapper.find("#read").exists()).toBe(true);
+    expect(wrapper.find("p").exists()).toBe(true); //likewise, the day the message was read should appear here.
   });
 });

--- a/src/components/atoms/ReadNotification.vue
+++ b/src/components/atoms/ReadNotification.vue
@@ -2,7 +2,6 @@
   <div
     v-if="dayRead"
     class="flex-auto items-baseline h-16 w-16 md:h-20 md:w-20"
-    id="read"
   >
     <p
       class="
@@ -20,7 +19,6 @@
   <div
     v-else
     class="flex place-items-center justify-center h-16 w-16 md:h-20 md:w-20"
-    id="not-read"
   >
     <div class="bg-alert-main rounded-full w-4 h-4" />
   </div>


### PR DESCRIPTION
## [VCON-144 (WCAG 4.1.1 Parsing)](https://decdvirtualconcierge.atlassian.net/browse/VCON-144?atlOrigin=eyJpIjoiYjg2NmJhMGVmNjU0NDdlZTg3MGMxMDdhNmIxYWRiNzUiLCJwIjoiaiJ9) 

### Description
Removed the id values in the ReadNotification component, as it raised an automatic issue in the Axe devtools for duplicate ids. 
Reproduction: Go to the [main site](https://virtual-assistant.toadfor.ca/en), click on the inbox item for Job Bank, and you should see the error in the Axe scan. 

### Additional Notes
Dunno if there's some functionality attached to this id attribute, I didn't see any. 
