### PR TITLE
un-reversed / re-reversed conversation window

### DIFF
--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -16,9 +16,9 @@
       <ul
         class="
           w-full
-          space-y-2 space-y-reverse
+          space-y-2
           overflow-auto
-          flex flex-col-reverse
+          flex flex-col
           font-body
           text-gray-dark
           py-2
@@ -28,6 +28,11 @@
         id="conversationWindow"
         tabindex="0"
       >
+        <li>
+          <p class="text-center font-heading text-sm font-light text-gray-dark">
+            {{ $t("messageTime") }}
+          </p>
+        </li>
         <ConversationMessage
           v-for="(message, index) in chatMessage.messages"
           :key="message.id"
@@ -35,13 +40,8 @@
           :text="message.text"
           :senderIcon="chatMessage.senderIcon"
           :senderIconAltText="chatMessage.senderIconAltText"
-          :isLastMessage="index === 0"
+          :isLastMessage="index === chatMessage.messages.length - 1"
         />
-        <li>
-          <p class="text-center font-heading text-sm font-light text-gray-dark">
-            {{ $t("messageTime") }}
-          </p>
-        </li>
       </ul>
     </div>
     <div class="sticky bottom-0">
@@ -100,4 +100,8 @@ export default {
   },
 };
 </script>
-<style scoped></style>
+<style scoped>
+#conversationWindow > :first-child {
+  margin-top: auto !important;
+}
+</style>

--- a/src/store/modules/chatMessages.js
+++ b/src/store/modules/chatMessages.js
@@ -17,10 +17,10 @@ const getters = {
           const firstDate = new Date(a.receivedTime).getTime();
           const secondDate = new Date(b.receivedTime).getTime();
           if (firstDate > secondDate) {
-            return -1;
+            return 1;
           }
           if (firstDate < secondDate) {
-            return 1;
+            return -1;
           }
           return 0;
         });


### PR DESCRIPTION
## [VCON-270](https://decdvirtualconcierge.atlassian.net/browse/VCON-270?atlOrigin=eyJpIjoiMDJmZjQxNzVhMTgyNDM3MGFlYTQ1ZWQxZTdmM2JjNzciLCJwIjoiaiJ9)

### Description
Re-reversed/un-reversed the conversation window's chat messages so they should now be in order when read out with a screen reader/not using css. 

### Additional Notes 
Thanks to [stack overflow](https://stackoverflow.com/questions/36130760/use-justify-content-flex-end-and-to-have-vertical-scrollbar) for always being there, even when I search up words that don't make proper sentences ♥. 
Only checked if the conversation started from the bottom and if the scrollbar didn't disappear, not sure if there's any other issues to check for/browser compatibility.