### PR TITLE
Get quick replies/suggested actions from bot into chatoption buttons

### DIFF
--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -22,7 +22,7 @@
       <chat-option-button
         v-for="(option, index) in buttonOptions"
         :key="index"
-        :text="option"
+        :text="option?.value ?? option"
         @send-button="sendBtnText"
       />
     </div>

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -18,7 +18,7 @@
     @input="checkSendBtnActive"
   />
   <div class="flex flex-row bg-gray-infolt text-gray-dark">
-    <div class="w-full">
+    <div class="w-full min-h-12">
       <chat-option-button
         v-for="(option, index) in buttonOptions"
         :key="index"

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -48,7 +48,7 @@
       <!-- The logic on how the buttonOptions are passed as props will
                    depend on how we get the possible answers from VA. -->
       <TextInput
-        :buttonOptions="suggestedActions ?? [$t('yes'), $t('no')]"
+        :buttonOptions="suggestedActions"
         @add-message="sendChatMessage"
       />
     </div>

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -83,9 +83,11 @@ export default {
       () => store.getters["inbox/isMobileDrawerOpen"]
     );
     const suggestedActions = computed(() => {
-      const messages = chatMessage.messages;
+      const messages = chatMessage.value.messages;
       const noMessages = messages.length === 0;
-      return noMessages ? null : messages[messages.length - 1].suggestedActions;
+      return noMessages
+        ? null
+        : messages[messages.length - 1].suggestedActions?.actions;
     });
 
     function sendChatMessage(msg) {
@@ -96,11 +98,21 @@ export default {
       store.dispatch("chatMessages/sendChatMessage", newMessage);
     }
 
+    function processSuggestedActions() {
+      const replies = suggestedActions.value; //shorter name
+      if (replies ?? true) return null;
+      console.log(replies);
+      console.log(replies[0]);
+      return replies;
+    }
+
     return {
       chatMessage,
       sendChatMessage,
       isMobileDrawerOpen,
       icons,
+      suggestedActions,
+      processSuggestedActions,
     };
   },
 };

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -48,7 +48,7 @@
       <!-- The logic on how the buttonOptions are passed as props will
                    depend on how we get the possible answers from VA. -->
       <TextInput
-        :buttonOptions="[$t('yes'), $t('no')]"
+        :buttonOptions="suggestedActions ?? [$t('yes'), $t('no')]"
         @add-message="sendChatMessage"
       />
     </div>
@@ -82,6 +82,11 @@ export default {
     const isMobileDrawerOpen = computed(
       () => store.getters["inbox/isMobileDrawerOpen"]
     );
+    const suggestedActions = computed(() => {
+      const messages = chatMessage.messages;
+      const noMessages = messages.length === 0;
+      return noMessages ? null : messages[messages.length - 1].suggestedActions;
+    });
 
     function sendChatMessage(msg) {
       const newMessage = {

--- a/src/services/chatMessages/chatMessages.js
+++ b/src/services/chatMessages/chatMessages.js
@@ -57,7 +57,6 @@ const receiveMessageHandler = () => {
   directLine.activity$.subscribe(
     (activity) => {
       // If messages need their own id, pass activity.id as a parameter in the function below.
-      console.log(activity);
       directLineMessageRecievedHandler(
         activity.from.name,
         activity.text,

--- a/src/services/chatMessages/chatMessages.js
+++ b/src/services/chatMessages/chatMessages.js
@@ -57,10 +57,12 @@ const receiveMessageHandler = () => {
   directLine.activity$.subscribe(
     (activity) => {
       // If messages need their own id, pass activity.id as a parameter in the function below.
+      console.log(activity);
       directLineMessageRecievedHandler(
         activity.from.name,
         activity.text,
-        activity.conversation.id
+        activity.conversation.id,
+        activity.suggestedActions
       );
     },
     (err) => console.log(err)

--- a/src/store/modules/chatMessages.js
+++ b/src/store/modules/chatMessages.js
@@ -42,11 +42,17 @@ const getters = {
 const actions = {
   initializeChatMessages({ dispatch, commit, rootGetters }) {
     commit("setDefaultState");
-    let directLineMessageRecievedHandler = (userName, message, convoId) => {
+    let directLineMessageRecievedHandler = (
+      userName,
+      message,
+      convoId,
+      suggestedActions
+    ) => {
       commit("addMessageToConversation", {
         id: convoId,
         isUser: "userName" === userName,
         text: message,
+        suggestedActions: suggestedActions,
       });
       if (convoId === rootGetters["inbox/getSelectedInboxItem"].id) {
         commit("setLastRead", convoId);
@@ -142,6 +148,7 @@ const mutations = {
       receivedTime: Date.now(),
       isUser: payload.isUser,
       text: payload.text,
+      suggestedActions: payload.suggestedActions,
     };
     // Add the new message to the correct conversation.
     conversation.messages.push(newMessage);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,6 +71,9 @@ module.exports = {
       },
       minWidth: {
         "7/2r": "3.5rem"
+      },
+      minHeight: {
+        "12": "3rem"
       }
     },
   },


### PR DESCRIPTION
## [VCON-294](https://decdvirtualconcierge.atlassian.net/browse/VCON-294) 

### Description
Got the suggestedActions thing from the bot, which allows us to use the quick replies given to us by the bot. 

### Additional Notes
At the moment I have it set to default to "Yes" or "No"/"Oui" ou "Non" as the default quick replies if none are sent from the bot.
For testing, at the moment it seems like only the prompt to rate the bot has suggestedActions. So, to test it efficiently, hit the No button. If the prompt gets sent in the wrong order (i.e. it isn't the last message) press No again.

### Screenshots:

#### Nothing sent by bot so it defaults to Yes/No
![image](https://user-images.githubusercontent.com/45071113/128746810-667e6e17-947e-49cc-9425-d94cb7565eaf.png)

#### Same thing but en français
![image](https://user-images.githubusercontent.com/45071113/128746872-7f76e536-a9c2-471d-a36c-560e5b159cb7.png)

#### Success!
![image](https://user-images.githubusercontent.com/45071113/128746927-2dbcf863-9463-440b-87aa-7d1b8d767358.png)

