### PR TITLE
fixed all the tests that broke

### DIFF
--- a/__tests__/components/atoms/ChatOptionButton.spec.js
+++ b/__tests__/components/atoms/ChatOptionButton.spec.js
@@ -1,21 +1,24 @@
 import { mount } from "@vue/test-utils";
+import { i18n } from "../../../i18n";
 import ChatOptionButton from "../../../src/components/atoms/ChatOptionButton";
 
 describe("ChatOptionButton component", () => {
-  it("ensures text button is displayed", () => {
-    const wrapper = mount(ChatOptionButton, {
-      props: {
-        text: "Yes",
-      },
+  const wrapper = mount(ChatOptionButton, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+
+  it("ensures text button is displayed", async () => {
+    await wrapper.setProps({
+      text: "Yes",
     });
     expect(wrapper.text()).toContain("Yes");
   });
 
-  it("ensures sendFormButton is called on click", () => {
-    const wrapper = mount(ChatOptionButton, {
-      props: {
-        text: "Yes",
-      },
+  it("ensures sendFormButton is called on click", async () => {
+    await wrapper.setProps({
+      text: "Yes",
     });
 
     const quickReplyBtn = wrapper.find("button");

--- a/__tests__/components/atoms/ConversationMessage.spec.js
+++ b/__tests__/components/atoms/ConversationMessage.spec.js
@@ -1,64 +1,59 @@
 import { mount } from "@vue/test-utils";
+import { i18n } from "../../../i18n";
 import ConversationMessage from "../../../src/components/atoms/ConversationMessage";
 
 describe("ConversationMessage component", () => {
-  it("ensures message is displayed", () => {
-    const wrapper = mount(ConversationMessage, {
-      props: {
-        text: "Hello test",
-      },
-    });
+  const wrapper = mount(ConversationMessage, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+
+  it("ensures message is displayed", async () => {
+    await wrapper.setProps({ text: "Hello test" });
     expect(wrapper.text()).toContain("Hello test");
   });
 
-  it("ensures message styling is from bot", () => {
-    const wrapper = mount(ConversationMessage, {
-      propsData: {
-        isUser: false,
-        isLastMessage: true,
-        text: "Hello test",
-      },
+  it("ensures message styling is from bot", async () => {
+    await wrapper.setProps({
+      isUser: false,
+      isLastMessage: true,
+      text: "Hello test",
     });
     expect(wrapper.classes()).toContain("flex");
-    const p = wrapper.find("p");
-    expect(p.classes()).toContain("botMessage");
+    const message = wrapper.find("h4");
+    expect(message.classes()).toContain("botMessage");
   });
 
-  it("ensures message styling is from user", () => {
-    const wrapper = mount(ConversationMessage, {
-      propsData: {
-        isUser: true,
-        isLastMessage: true,
-        text: "Hello test",
-      },
+  it("ensures message styling is from user", async () => {
+    await wrapper.setProps({
+      isUser: true,
+      isLastMessage: true,
+      text: "Hello test",
     });
     expect(wrapper.classes()).not.toContain("flex");
-    const p = wrapper.find("p");
-    expect(p.classes()).toContain("userMessage");
+    const message = wrapper.find("h4");
+    expect(message.classes()).toContain("userMessage");
   });
 
-  it("ensures last message shows img", () => {
-    const wrapper = mount(ConversationMessage, {
-      propsData: {
-        senderIcon: "VA",
-        senderIconAltText: "img alt text",
-        isUser: true,
-        isLastMessage: true,
-        text: "this is my last message",
-      },
+  it("ensures last message shows img", async () => {
+    await wrapper.setProps({
+      senderIcon: "VA",
+      senderIconAltText: "img alt text",
+      isUser: true,
+      isLastMessage: true,
+      text: "this is my last message",
     });
     expect(wrapper.find("img")).toBeTruthy();
   });
 
-  it("ensures not last message does not show img", () => {
-    const wrapper = mount(ConversationMessage, {
-      propsData: {
-        senderIcon: "VA",
-        senderIconAltText: "img alt text",
-        isUser: true,
-        isLastMessage: false,
-        text: "this is my last message",
-      },
+  it("ensures not last message does not show img", async () => {
+    await wrapper.setProps({
+      senderIcon: "VA",
+      senderIconAltText: "img alt text",
+      isUser: true,
+      isLastMessage: false,
+      text: "this is my last message",
     });
     expect(wrapper.find("img").exists()).toBe(false);
   });

--- a/__tests__/components/atoms/ConversationMessage.spec.js
+++ b/__tests__/components/atoms/ConversationMessage.spec.js
@@ -21,8 +21,8 @@ describe("ConversationMessage component", () => {
       text: "Hello test",
     });
     expect(wrapper.classes()).toContain("flex");
-    const message = wrapper.find("h4");
-    expect(message.classes()).toContain("botMessage");
+    const botMessage = wrapper.find(".botMessage");
+    expect(botMessage.exists()).toBe(true);
   });
 
   it("ensures message styling is from user", async () => {
@@ -32,8 +32,8 @@ describe("ConversationMessage component", () => {
       text: "Hello test",
     });
     expect(wrapper.classes()).not.toContain("flex");
-    const message = wrapper.find("h4");
-    expect(message.classes()).toContain("userMessage");
+    const userMessage = wrapper.find(".userMessage");
+    expect(userMessage.exists()).toBe(true);
   });
 
   it("ensures last message shows img", async () => {

--- a/__tests__/components/atoms/ReadNotification.spec.js
+++ b/__tests__/components/atoms/ReadNotification.spec.js
@@ -1,20 +1,27 @@
 import { mount } from "@vue/test-utils";
+import { i18n } from "../../../i18n";
 import ReadNotification from "../../../src/components/atoms/ReadNotification";
 
 describe("ReadNotification component", () => {
+  const wrapper = mount(ReadNotification, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+
   const dayReadProp = "Monday";
-  it("ensures that the read notification is displayed", () => {
-    const wrapper = mount(ReadNotification, {
-      props: {
-        dayRead: dayReadProp,
-      },
+  it("ensures that the read notification is displayed", async () => {
+    await wrapper.setProps({
+      dayRead: dayReadProp,
     });
     expect(wrapper.text()).toContain(dayReadProp); //check that prop is displayed
   });
 
   // false/empty by default (not read)
-  it("ensures ReadNotification icon is shown (message has not been read)", () => {
-    const wrapper = mount(ReadNotification);
+  it("ensures ReadNotification icon is shown (message has not been read)", async () => {
+    await wrapper.setProps({
+      dayRead: "",
+    });
     expect(wrapper.text()).toBe(""); //unread notification has no text
   });
 });

--- a/__tests__/components/molecules/MessageCard.spec.js
+++ b/__tests__/components/molecules/MessageCard.spec.js
@@ -11,7 +11,10 @@ describe("MessageCard component", () => {
         plugins: [i18n],
       },
       props: {
-        timestamp: "test timestamp",
+        timestamps: {
+          shortTimestamp: "test timestamp",
+          fullTimestamp: "tst tmstmp",
+        },
         title: "test title",
         paragraphs: "test paragraphs",
       },
@@ -20,6 +23,10 @@ describe("MessageCard component", () => {
 
   it("Check for timestamp text in MessageCard", () => {
     expect(wrapper.text()).toContain("test timestamp");
+  });
+
+  it("Check for abbreviated timestamp text in MessageCard", () => {
+    expect(wrapper.text()).toContain("tst tmstmp");
   });
 
   it("Check for title text in MessageCard", () => {

--- a/src/components/molecules/MessageCard.vue
+++ b/src/components/molecules/MessageCard.vue
@@ -16,7 +16,7 @@
 <script>
 export default {
   props: {
-    timestamps: Object,
+    timestamps: Object, // should be in form {shortTimestamp: String, fullTimestamp: String}
     title: String,
     paragraphs: String, //note that newlines will be preserved
   },

--- a/src/store/modules/__mocks__/chatMessages.js
+++ b/src/store/modules/__mocks__/chatMessages.js
@@ -6,14 +6,16 @@ const getters = {
   getChatMessageByIdOrderedByMessagesDate: (state, getters) => (id) => {
     return {
       id: 1,
-      messages: {
-        id: 1,
-        receivedTime: new Date(2018, 11, 24, 10, 33, 30, 0),
-        isUser: true,
-        text: "test message text",
-        senderIcon: "test icon",
-        senderIconAltText: "test alt text",
-      },
+      messages: [
+        {
+          id: 1,
+          receivedTime: new Date(2018, 11, 24, 10, 33, 30, 0),
+          isUser: true,
+          text: "test message text",
+          senderIcon: "test icon",
+          senderIconAltText: "test alt text",
+        },
+      ],
     };
   },
   getAllChatMessages(state) {


### PR DESCRIPTION
## Not sure if there's a VCON issue attached — Feel free to add that here

### Description
Fixes broken tests — They seem to all have broken due to certain changes in implementation... will try to figure out ways to make the tests less reliant on implementation details as well. Some broke partially or entirely due to not including the i18n plugin.

Quick run-down on why each test broke:
MessageCard: props weren't updated in tests
ChatMessages: p tag was changed to h4; test tried to find p tag unsuccessfully. also i18n was used for hidden text
ChatOptionButton: i18n was used for hidden text
ConversationWindow: mocked messages is supposed to be an array; wasn't, so it failed
ReadNotification: i18n was used for hidden text

