### PR TITLE
Update tailwindconfig to purge all other css and minify the same.

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,4 +88,5 @@ module.exports = {
     }
   },
   plugins: [],
+  purge: ["./src/**/*.vue", "./src/**/*.jsx"],
 };


### PR DESCRIPTION
## [VCON-XXX](url) (Link to issue on Jira)

### I don't think I've a JIRA issue linked to this

- Updating the tailwind config file so that it purges vue components and adds only tailwind's css.
- Reduced the CSS file from around 5 MB to 8 Kb
- Also fixed the warning when running `npm run build`
- Tested it out on my local machine by serving from dist folder.
