### PR TITLE
changed heading levels and changed headers to spans where applicable

### DIFF
--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -8,8 +8,7 @@
     @keydown.prevent.down="nextElement($event)"
     @keydown.prevent.exact.tab="nextElement($event)"
   >
-    <!-- <span class="sr-only">{{ (isUser ? "You " : senderName) }} said:</span> -->
-    <h4
+    <span
       :aria-label="(isUser ? $t('you') : senderName) + $t('said') + text"
       :class="[
         !isUser
@@ -24,7 +23,7 @@
       ]"
     >
       {{ text }}
-    </h4>
+    </span>
     <img
       v-if="isLastMessage"
       ref="chatReaderIcon"

--- a/src/components/atoms/DateModified.vue
+++ b/src/components/atoms/DateModified.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="p-2 font-body text-gray-dark text-xs sm:text-sm">
     <!-- for now this just displays the current date -->
-    <p>{{ $t("dateModified") }} {{ Date() }}</p>
+    <span
+      >{{ $t("dateModified") }} <time> {{ Date() }}</time>
+    </span>
   </div>
 </template>

--- a/src/components/atoms/ReadNotification.vue
+++ b/src/components/atoms/ReadNotification.vue
@@ -3,12 +3,8 @@
     v-if="dayRead"
     class="flex-auto items-baseline h-16 w-16 md:h-20 md:w-20"
   >
-    <span class="hidden" :id="'day-read-label-' + indexNum">{{
-      $t("msgSentOn")
-    }}</span>
-    <h3
-      :id="'day-read-' + indexNum"
-      :aria-labelledby="'day-read-label-' + indexNum + ' day-read-' + indexNum"
+    <span
+      :aria-label="$t('msgSentOn') + ' ' + dayRead"
       class="
         font-heading font-light
         text-sm
@@ -19,7 +15,7 @@
       "
     >
       {{ dayRead }}.
-    </h3>
+    </span>
   </div>
   <div
     v-else

--- a/src/components/molecules/Inbox.vue
+++ b/src/components/molecules/Inbox.vue
@@ -15,14 +15,14 @@
     <span :id="'inboxHeaderDesc'" class="hidden">
       Inbox header, press tab or click to access inbox items
     </span>
-    <h1
+    <h2
       id="inbox-header"
       :aria-labelledby="'inboxHeaderDesc'"
       class="font-heading font-bold text-4xl px-3 pt-6 pb-3 focus:ring-inset"
       @blur="$event.target.tabIndex = -1"
     >
       {{ $t("inbox") }}
-    </h1>
+    </h2>
     <ul class="sm:overflow-auto space-y-1" role="list">
       <inbox-item
         v-for="(inboxItem, index) in inboxItems"

--- a/src/components/molecules/Inbox.vue
+++ b/src/components/molecules/Inbox.vue
@@ -15,14 +15,14 @@
     <span :id="'inboxHeaderDesc'" class="hidden">
       {{ $t("inboxHeaderDesc") }}
     </span>
-    <h2
+    <h1
       id="inbox-header"
       :aria-labelledby="'inboxHeaderDesc'"
       class="font-heading font-bold text-4xl px-3 pt-6 pb-3 focus:ring-inset"
       @blur="$event.target.tabIndex = -1"
     >
       {{ $t("inbox") }}
-    </h2>
+    </h1>
     <ul class="sm:overflow-auto space-y-1">
       <inbox-item
         v-for="(inboxItem, index) in inboxItems"

--- a/src/components/molecules/InboxItem.vue
+++ b/src/components/molecules/InboxItem.vue
@@ -27,7 +27,7 @@
       <span :id="'sender-name-label-' + indexNum" class="hidden">
         {{ $t("inboxFor") }}
       </span>
-      <h3
+      <h2
         :id="'sender-name-' + indexNum"
         :aria-labelledby="
           'sender-name-label-' + indexNum + ' sender-name-' + indexNum
@@ -38,7 +38,7 @@
         ]"
       >
         {{ inboxItem.senderName }}
-      </h3>
+      </h2>
       <span
         :id="'teaser-text-' + indexNum"
         :aria-label="

--- a/src/components/molecules/InboxItem.vue
+++ b/src/components/molecules/InboxItem.vue
@@ -28,7 +28,7 @@
       <span :id="'sender-name-label-' + indexNum" class="hidden">
         {{ $t("inboxFor") }}
       </span>
-      <h2
+      <h3
         :id="'sender-name-' + indexNum"
         :aria-labelledby="
           'sender-name-label-' + indexNum + ' sender-name-' + indexNum
@@ -39,22 +39,20 @@
         ]"
       >
         {{ inboxItem.senderName }}
-      </h2>
-      <span class="hidden" :id="'status-and-teaser-announcement-' + indexNum"
-        >{{
-          inboxItem.selected === true
-            ? $t("currentlySelected")
-            : $t("accessInboxItem") +
-              (inboxItem.dayRead ? $t("alreadyRead") : $t("unread"))
-        }}. {{ $t("teaserText") }}:</span
-      >
-      <h2
+      </h3>
+      <span
         :id="'teaser-text-' + indexNum"
-        :aria-labelledby="
-          'status-and-teaser-announcement-' +
-          indexNum +
-          ' teaser-text-' +
-          indexNum
+        :aria-label="
+          (inboxItem.selected === true
+            ? $t('currentlySelected')
+            : $t('accessInboxItem')) +
+          (inboxItem.dayRead ? $t('alreadyRead') : $t('unread')) +
+          '.' +
+          $t('teaserText') +
+          ':' +
+          inboxItem.teaserText
+            ? inboxItem.teaserText
+            : 'No messages available'
         "
         :class="[
           !inboxItem.dayRead ? 'font-body' : 'font-heading font-light',
@@ -64,7 +62,7 @@
         {{
           inboxItem.teaserText ? inboxItem.teaserText : "No messages available"
         }}
-      </h2>
+      </span>
     </div>
     <div>
       <read-notification

--- a/src/components/molecules/MessageCard.vue
+++ b/src/components/molecules/MessageCard.vue
@@ -6,7 +6,7 @@
     <span aria-hidden="true" class="uppercase text-sm font-heading font-light">
       {{ timestamps.shortTimestamp }}
     </span>
-    <h4 class="font-heading text-2xl font-bold">{{ title }}</h4>
+    <h3 class="font-heading text-2xl font-bold">{{ title }}</h3>
     <p class="font-normal font-body text-lg whitespace-pre-line">
       {{ paragraphs }}
     </p>

--- a/src/components/molecules/MessageCard.vue
+++ b/src/components/molecules/MessageCard.vue
@@ -6,7 +6,7 @@
     <span aria-hidden="true" class="uppercase text-sm font-heading font-light">
       {{ timestamps.shortTimestamp }}
     </span>
-    <h2 class="font-heading text-2xl font-bold">{{ title }}</h2>
+    <h4 class="font-heading text-2xl font-bold">{{ title }}</h4>
     <p class="font-normal font-body text-lg whitespace-pre-line">
       {{ paragraphs }}
     </p>


### PR DESCRIPTION
## [VA-81](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-81) and  [VA-84](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-84) 

### Description
Heading level changes: 
- Inbox heading from h1 to h2 (I'm assuming we're going to bring the Service Canada Labs banner back at some point)
- Inbox sender name from h2 to h3
- Message card from h2 to h4 (as it is semantically under the sender name). Note that this may raise an Axe devtools issue 

Changed headers to spans for:
 - readnotification
 - chat message
 - message preview in the Inbox component

### Additional Notes
Axe devtools issues are raised for the spans as they have aria-labels attached to them — sr-only text may be more suitable