### PR TITLE
VA-78 translated alt text for header and footer

### DIFF
--- a/src/components/molecules/TheFooter.vue
+++ b/src/components/molecules/TheFooter.vue
@@ -18,7 +18,7 @@
             <img
               className="h-6 sm:h-8"
               src="../../assets/wmms-blk.svg"
-              alt="canada logo"
+              :alt="$t('canadaLogoFooter')"
             />
           </div>
         </div>

--- a/src/components/molecules/TheHeader.vue
+++ b/src/components/molecules/TheHeader.vue
@@ -49,7 +49,7 @@
             <img
               className="h-5 xs:h-7 sm:h-8 md:h-9 mx-3 xs:mx-0"
               src="../../assets/sig-blk-en.svg"
-              alt="canada logo en"
+              :alt="$t('canadaLogoHeader')"
             />
             <a
               id="lang-toggle-small"
@@ -91,7 +91,7 @@
           text="menu"
         ></Menu>
       </div> -->
-      <!-- The banner with bg image is hidden but can be reshown if needed -->
+      <!-- The banner with bg image is hidden but can be reshown if needed (image has a white edge) -->
       <!-- <div class="sm:py-4">
         <Banner :title="$t('bannerTitle')" :body="$t('bannerBody')"></Banner>
       </div> -->

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,8 @@
   "changeLanguage": "Français",
   "changeLanguageTo": "Changer la langue en ",
   "changeLanguageAbrv": "FR",
+  "canadaLogoHeader": "Government of Canada",
+  "canadaLogoFooter": "Symbol of the Government of Canada",
   "bannerTitle": "Service Canada Labs",
   "bannerBody": "This site will change as we test ideas",
   "inbox": "Inbox",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -4,6 +4,8 @@
   "changeLanguage": "English",
   "changeLanguageTo": "Change the language to ",
   "changeLanguageAbrv": "EN",
+  "canadaLogoHeader": "Gouvernement du Canada",
+  "canadaLogoFooter": "Symbole du gouvernement du Canada",
   "bannerTitle": "Laboratoires de Service Canada",
   "bannerBody": "Ce site changera au fur et à mesure que nous testerons des idées",
   "inbox": "Boîte de réception",

--- a/src/views/Splash.vue
+++ b/src/views/Splash.vue
@@ -19,7 +19,7 @@
         <img
           class="h-auto w-64 container mx-auto pt-6 xl:w-2/3 xl:mx-0 xl:px-6"
           src="../assets/sig-blk-en.svg"
-          :alt="$t('canadaLogoHeader')"
+          alt="Government of Canada / Gouvernement du Canada"
         />
         <div class="flex w-max container py-11 mx-auto font-display">
           <router-link

--- a/src/views/Splash.vue
+++ b/src/views/Splash.vue
@@ -19,7 +19,7 @@
         <img
           class="h-auto w-64 container mx-auto pt-6 xl:w-2/3 xl:mx-0 xl:px-6"
           src="../assets/sig-blk-en.svg"
-          alt="Symbol of the Government of Canada"
+          :alt="$t('canadaLogoHeader')"
         />
         <div class="flex w-max container py-11 mx-auto font-display">
           <router-link
@@ -129,7 +129,7 @@
         <img
           class="h-auto w-24 xl:w-28"
           src="../assets/wmms-blk.svg"
-          alt="Symbol of the Government of Canada"
+          :alt="$t('canadaLogoFooter')"
         />
       </div>
     </div>


### PR DESCRIPTION
## [VA-78](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-78)

### Description
resolves the issue with the not very descriptive alt text for the canada logos in the header and footer. 
_Providing a text alternative that is not null (e.g., alt=spacer" or alt="image") for images that should be ignored by assistive technology"_
translated the text.

### Additional Notes
