### PR TITLE
VA-77 removed alt for decorative icon

### DIFF
--- a/src/components/molecules/InboxItem.vue
+++ b/src/components/molecules/InboxItem.vue
@@ -17,7 +17,7 @@
         v-if="inboxItem.senderIcon"
         class="w-12 h-12 md:w-12 md:h-12"
         :src="icons[inboxItem.senderIcon]"
-        alt="Inbox icon."
+        alt=""
       />
       <div
         v-else


### PR DESCRIPTION
## [VA-77](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-77)

### Description
Under heading "Inbox", The virtual assistant icon in the first Tab, is not a functional image and does not add any value to the content. It should be marked as decorative by leaving the alt="" attribute empty to allow screen reader to ignore it.

### Additional Notes
