### PR TITLE
VA-72 Add aria-live to message list

### DIFF
--- a/src/components/atoms/ConversationMessage.vue
+++ b/src/components/atoms/ConversationMessage.vue
@@ -7,6 +7,7 @@
     @keydown.prevent.shift.tab="prevElement($event)"
     @keydown.prevent.down="nextElement($event)"
     @keydown.prevent.exact.tab="nextElement($event)"
+    aria-live="polite"
   >
     <!-- <span class="sr-only">{{ (isUser ? "You " : senderName) }} said:</span> -->
     <h4

--- a/src/components/molecules/MessageCard.vue
+++ b/src/components/molecules/MessageCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <li class="bg-white p-6 space-y-3 text-gray-dark">
+  <li class="bg-white p-6 space-y-3 text-gray-dark" aria-live="polite">
     <span class="sr-only">
       {{ timestamps.fullTimestamp }}
     </span>

--- a/src/components/molecules/MessageList.vue
+++ b/src/components/molecules/MessageList.vue
@@ -10,7 +10,6 @@
       class="flex bg-gray-infolt flex-col p-6 space-y-6 overflow-auto"
       id="messageList"
       tabindex="0"
-      aria-live="polite"
     >
       <message-card
         v-for="email of mailObject.emails"

--- a/src/components/molecules/MessageList.vue
+++ b/src/components/molecules/MessageList.vue
@@ -10,6 +10,7 @@
       class="flex bg-gray-infolt flex-col p-6 space-y-6 overflow-auto"
       id="messageList"
       tabindex="0"
+      aria-live="polite"
     >
       <message-card
         v-for="email of mailObject.emails"

--- a/src/components/organisms/ConversationWindow.vue
+++ b/src/components/organisms/ConversationWindow.vue
@@ -30,6 +30,7 @@
         aria-label="Press enter to begin navigating through the chat messages and input box. Use the up and down arrow keys to navigate between each message, going all the way down lets you reach the input box. You may also use tab/shift+tab, and press shift+enter to view the latest chat message. Press escape to exit."
         @keyup.exact.enter="accessIndividualMessages(0)"
         @keyup.shift.enter="accessIndividualMessages(-1)"
+        aria-live="polite"
       >
         <li>
           <p class="text-center font-heading text-sm font-light text-gray-dark">


### PR DESCRIPTION
## [VA-72](https://jira-dev.bdm-dev.dts-stn.com/browse/VA-72)

### Description

Screen reader users are not notified when they send a message, and they are not notified about any of the new messages they received in the conversation section. They will need to navigate back and read all the messages in order to understand the conversation. Use aria-live to provide users with notifications. The following page contains guidelines about how to create accessible chat chatbot for all users: https://a11y-guidelines.orange.com/en/web/components-examples/chatbot/ 

Added `aria-live` to the ul message list 

### Additional Notes

Nope